### PR TITLE
Add ability to execute scripts through direct SQL

### DIFF
--- a/Milyli.ScriptRunner.Agent/DependencyResolution/AgentRegistry.cs
+++ b/Milyli.ScriptRunner.Agent/DependencyResolution/AgentRegistry.cs
@@ -2,29 +2,32 @@
 // Copyright © 2016 Milyli
 // </copyright>
 
-using Milyli.ScriptRunner.Core.Relativity.Interfaces;
-using Milyli.ScriptRunner.Core.Repositories;
-using Milyli.ScriptRunner.Core.Repositories.Interfaces;
-
 namespace Milyli.ScriptRunner.Agent.DependencyResolution
 {
-    using Core.DependencyResolution;
-    using Core.Relativity.Client;
-    using Core.Services;
-    using MilyliDependencies.Framework.Relativity;
-    using Relativity.API;
-    using StructureMap;
+	using Core.DependencyResolution;
+	using Core.Relativity.Client;
+	using Core.Services;
+	using Milyli.ScriptRunner.Core.Relativity.Interfaces;
+	using Milyli.ScriptRunner.Core.Repositories;
+	using Milyli.ScriptRunner.Core.Repositories.Interfaces;
+	using MilyliDependencies.Framework.Relativity;
+	using Relativity.API;
+	using Relativity.Services.Objects;
+	using StructureMap;
 
-    public class AgentRegistry : Registry
-    {
-        public AgentRegistry(IHelper helper)
-        {
-            this.For<IHelper>().Use(helper);
-            this.For<IRelativityContext>().Use(new RelativityContext(-1));
-            this.For<IRelativityClientFactory>().Use<RsapiClientFactory>();
-            this.For<IInstanceConnectionFactory>().Use<RelativityInstanceConnectionFactory>();
-            this.For<IRelativityScriptRunner>().Use<RelativityScriptRunner>();
-            this.IncludeRegistry(new ScriptRunnerRegistry());
-        }
-    }
+	public class AgentRegistry : Registry
+	{
+		public AgentRegistry(IHelper helper)
+		{
+			this.For<IHelper>().Use(helper);
+			this.For<IServicesMgr>().Use(helper.GetServicesManager());
+			this.For<IObjectManager>().Use(ctx => ctx.GetInstance<IServicesMgr>().CreateProxy<IObjectManager>(ExecutionIdentity.System)).ContainerScoped();
+
+			this.For<IRelativityContext>().Use(new RelativityContext(-1));
+			this.For<IRelativityClientFactory>().Use<RsapiClientFactory>();
+			this.For<IInstanceConnectionFactory>().Use<RelativityInstanceConnectionFactory>();
+			this.For<IRelativityScriptRunner>().Use<RelativityScriptRunner>();
+			this.IncludeRegistry(new ScriptRunnerRegistry());
+		}
+	}
 }

--- a/Milyli.ScriptRunner.Agent/Milyli.ScriptRunner.Agent.csproj
+++ b/Milyli.ScriptRunner.Agent/Milyli.ScriptRunner.Agent.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Milyli.ScriptRunner.Agent</RootNamespace>
     <AssemblyName>Milyli.ScriptRunner.Agent</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -38,14 +39,14 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="kCura.Agent, Version=9.5.69.85, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\Solutions\packages\Relativity.Agent.9.5.69.85\lib\kCura.Agent.dll</HintPath>
+    <Reference Include="kCura.Agent, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Agent.9.6.284.6\lib\kCura.Agent.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.EventHandler, Version=9.5.69.85, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.5.69.85\lib\kCura.EventHandler.dll</HintPath>
+    <Reference Include="kCura.EventHandler, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.6.284.6\lib\kCura.EventHandler.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Relativity.Client, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.5.69.85\lib\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.6.284.6\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
     <Reference Include="linq2db, Version=1.0.7.6, Culture=neutral, PublicKeyToken=f19f8aed7feff67e, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\linq2db.1.7.6\lib\net45\linq2db.dll</HintPath>
@@ -53,20 +54,20 @@
     <Reference Include="NLog, Version=5.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\NLog.5.0.0-beta09\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Api.9.5.69.85\lib\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Api.9.6.284.6\lib\Relativity.API.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Kepler, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Kepler.dll</HintPath>
+    <Reference Include="Relativity.Kepler, Version=1.0.1.445, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Kepler.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.DataContracts, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.DataContracts.dll</HintPath>
+    <Reference Include="Relativity.Services.DataContracts, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.DataContracts.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.Interfaces, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.Interfaces.dll</HintPath>
+    <Reference Include="Relativity.Services.Interfaces, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.ServiceProxy.dll</HintPath>
+    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.392, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.4.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\StructureMap.4.4.5\lib\net45\StructureMap.dll</HintPath>

--- a/Milyli.ScriptRunner.Agent/app.config
+++ b/Milyli.ScriptRunner.Agent/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="linq2db" publicKeyToken="f19f8aed7feff67e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.7.5" newVersion="1.0.7.5" />
+        <assemblyIdentity name="linq2db" publicKeyToken="f19f8aed7feff67e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.0.7.5" newVersion="1.0.7.5"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/Milyli.ScriptRunner.Agent/packages.config
+++ b/Milyli.ScriptRunner.Agent/packages.config
@@ -5,11 +5,11 @@
   <package id="linq2db" version="1.7.6" targetFramework="net452" />
   <package id="Milyli.CodeAnalysis" version="2.0.1" targetFramework="net452" />
   <package id="NLog" version="5.0.0-beta09" targetFramework="net452" />
-  <package id="Relativity.Agent" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.Api" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.EventHandler" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.ObjectManager" version="9.5.162.111" targetFramework="net452" />
-  <package id="Relativity.Rsapi" version="9.5.69.85" targetFramework="net452" />
+  <package id="Relativity.Agent" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Api" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.EventHandler" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Rsapi" version="9.6.284.6" targetFramework="net452" />
   <package id="StructureMap" version="4.4.5" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Milyli.ScriptRunner.Core.Test/Milyli.ScriptRunner.Core.Test.csproj
+++ b/Milyli.ScriptRunner.Core.Test/Milyli.ScriptRunner.Core.Test.csproj
@@ -9,8 +9,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Milyli.ScriptRunner.Core.Test</RootNamespace>
     <AssemblyName>Milyli.ScriptRunner.Core.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -39,11 +40,11 @@
     <Reference Include="Castle.Core, Version=3.3.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\Castle.Core.3.3.0\lib\net45\Castle.Core.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.EventHandler, Version=9.5.69.85, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.5.69.85\lib\kCura.EventHandler.dll</HintPath>
+    <Reference Include="kCura.EventHandler, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.6.284.6\lib\kCura.EventHandler.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Relativity.Client, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.5.69.85\lib\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.6.284.6\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
     <Reference Include="linq2db, Version=1.0.7.6, Culture=neutral, PublicKeyToken=f19f8aed7feff67e, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\linq2db.1.7.6\lib\net45\linq2db.dll</HintPath>
@@ -57,20 +58,20 @@
     <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Api.9.5.69.85\lib\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Api.9.6.284.6\lib\Relativity.API.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Kepler, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Kepler.dll</HintPath>
+    <Reference Include="Relativity.Kepler, Version=1.0.1.445, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Kepler.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.DataContracts, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.DataContracts.dll</HintPath>
+    <Reference Include="Relativity.Services.DataContracts, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.DataContracts.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.Interfaces, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.Interfaces.dll</HintPath>
+    <Reference Include="Relativity.Services.Interfaces, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.ServiceProxy.dll</HintPath>
+    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.392, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.4.5.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\StructureMap.4.4.5\lib\net45\StructureMap.dll</HintPath>

--- a/Milyli.ScriptRunner.Core.Test/Milyli.ScriptRunner.Core.Test.csproj
+++ b/Milyli.ScriptRunner.Core.Test/Milyli.ScriptRunner.Core.Test.csproj
@@ -1,5 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\Solutions\packages\NUnit.3.11.0\build\NUnit.props" Condition="Exists('..\Solutions\packages\NUnit.3.11.0\build\NUnit.props')" />
+  <Import Project="..\Solutions\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props" Condition="Exists('..\Solutions\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -12,6 +14,8 @@
     <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <NuGetPackageImportStamp>
+    </NuGetPackageImportStamp>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -55,8 +59,8 @@
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\NLog.4.4.6\lib\net45\NLog.dll</HintPath>
     </Reference>
-    <Reference Include="nunit.framework, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\NUnit.3.6.1\lib\net45\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.11.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\NUnit.3.11.0\lib\net45\nunit.framework.dll</HintPath>
     </Reference>
     <Reference Include="Relativity.API, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\Relativity.Api.9.6.284.6\lib\Relativity.API.dll</HintPath>
@@ -93,7 +97,9 @@
     <Compile Include="IntegrationTests\TestJobScheduleRepository.cs" />
     <Compile Include="IntegrationTests\TestRelativityScriptRepository.cs" />
     <Compile Include="IntegrationTests\TestRelativityWorkspaceRepository.cs" />
+    <Compile Include="UnitTests\DBContextStub.cs" />
     <Compile Include="UnitTests\Mocks\JobScheduleRepositoryMock.cs" />
+    <Compile Include="UnitTests\RelativityScriptProcessorTests.cs" />
     <Compile Include="UnitTests\TestBitmaskHelper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="UnitTests\TestJobSchedule.cs" />
@@ -134,6 +140,13 @@
     </AdditionalFiles>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\Solutions\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\Solutions\packages\NUnit3TestAdapter.3.13.0\build\net35\NUnit3TestAdapter.props'))" />
+    <Error Condition="!Exists('..\Solutions\packages\NUnit.3.11.0\build\NUnit.props')" Text="$([System.String]::Format('$(ErrorText)', '..\Solutions\packages\NUnit.3.11.0\build\NUnit.props'))" />
+  </Target>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/Milyli.ScriptRunner.Core.Test/UnitTests/DBContextStub.cs
+++ b/Milyli.ScriptRunner.Core.Test/UnitTests/DBContextStub.cs
@@ -1,0 +1,218 @@
+﻿namespace Milyli.ScriptRunner.Core.Test.UnitTests
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Data;
+	using System.Data.Common;
+	using System.Data.SqlClient;
+	using global::Relativity.API;
+
+	public class DBContextStub : IDBContext
+	{
+		public string Database => throw new NotImplementedException();
+
+		public string ServerName { get; set; }
+
+		public bool IsMasterDatabase { get; set; }
+
+		public void BeginTransaction()
+		{
+			throw new NotImplementedException();
+		}
+
+		public void Cancel()
+		{
+			throw new NotImplementedException();
+		}
+
+		public void CommitTransaction()
+		{
+			throw new NotImplementedException();
+		}
+
+		public DbParameter CreateDbParameter()
+		{
+			throw new NotImplementedException();
+		}
+
+		public int ExecuteNonQuerySQLStatement(string sqlStatement)
+		{
+			throw new NotImplementedException();
+		}
+
+		public int ExecuteNonQuerySQLStatement(string sqlStatement, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public int ExecuteNonQuerySQLStatement(string sqlStatement, IEnumerable<SqlParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public int ExecuteNonQuerySQLStatement(string sqlStatement, IEnumerable<SqlParameter> parameters, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public SqlDataReader ExecuteParameterizedSQLStatementAsReader(string sqlStatement, IEnumerable<SqlParameter> parameters, int timeoutValue = -1, bool sequentialAccess = false)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DbDataReader ExecuteProcedureAsReader(string procedureName, IEnumerable<SqlParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public int ExecuteProcedureNonQuery(string procedureName, IEnumerable<SqlParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataSet ExecuteSqlStatementAsDataSet(string sqlStatement)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataSet ExecuteSqlStatementAsDataSet(string sqlStatement, IEnumerable<SqlParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataSet ExecuteSqlStatementAsDataSet(string sqlStatement, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataSet ExecuteSqlStatementAsDataSet(string sqlStatement, IEnumerable<SqlParameter> parameters, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataTable ExecuteSqlStatementAsDataTable(string sqlStatement)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataTable ExecuteSqlStatementAsDataTable(string sqlStatement, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataTable ExecuteSqlStatementAsDataTable(string sqlStatement, IEnumerable<SqlParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataTable ExecuteSqlStatementAsDataTable(string sqlStatement, int timeoutValue, IEnumerable<SqlParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DbDataReader ExecuteSqlStatementAsDbDataReader(string sqlStatement)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DbDataReader ExecuteSqlStatementAsDbDataReader(string sqlStatement, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DbDataReader ExecuteSqlStatementAsDbDataReader(string sqlStatement, IEnumerable<DbParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DbDataReader ExecuteSqlStatementAsDbDataReader(string sqlStatement, IEnumerable<DbParameter> parameters, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public IEnumerable<T> ExecuteSQLStatementAsEnumerable<T>(string sqlStatement, Func<SqlDataReader, T> converter, int timeout = -1)
+		{
+			throw new NotImplementedException();
+		}
+
+		public SqlDataReader ExecuteSQLStatementAsReader(string sqlStatement, int timeout = -1)
+		{
+			throw new NotImplementedException();
+		}
+
+		public T ExecuteSqlStatementAsScalar<T>(string sqlStatement)
+		{
+			throw new NotImplementedException();
+		}
+
+		public T ExecuteSqlStatementAsScalar<T>(string sqlStatement, IEnumerable<SqlParameter> parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public T ExecuteSqlStatementAsScalar<T>(string sqlStatement, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public T ExecuteSqlStatementAsScalar<T>(string sqlStatement, IEnumerable<SqlParameter> parameters, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public T ExecuteSqlStatementAsScalar<T>(string sqlStatement, params SqlParameter[] parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public object ExecuteSqlStatementAsScalar(string sqlStatement, params SqlParameter[] parameters)
+		{
+			throw new NotImplementedException();
+		}
+
+		public object ExecuteSqlStatementAsScalar(string sqlStatement, IEnumerable<SqlParameter> parameters, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public object ExecuteSqlStatementAsScalarWithInnerTransaction(string sqlStatement, IEnumerable<SqlParameter> parameters, int timeoutValue)
+		{
+			throw new NotImplementedException();
+		}
+
+		public DataTable ExecuteSQLStatementGetSecondDataTable(string sqlStatement, int timeout = -1)
+		{
+			throw new NotImplementedException();
+		}
+
+		public SqlConnection GetConnection()
+		{
+			throw new NotImplementedException();
+		}
+
+		public SqlConnection GetConnection(bool openConnectionIfClosed)
+		{
+			throw new NotImplementedException();
+		}
+
+		public SqlTransaction GetTransaction()
+		{
+			throw new NotImplementedException();
+		}
+
+		public void ReleaseConnection()
+		{
+			throw new NotImplementedException();
+		}
+
+		public void RollbackTransaction()
+		{
+			throw new NotImplementedException();
+		}
+
+		public void RollbackTransaction(Exception originatingException)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Milyli.ScriptRunner.Core.Test/UnitTests/RelativityScriptProcessorTests.cs
+++ b/Milyli.ScriptRunner.Core.Test/UnitTests/RelativityScriptProcessorTests.cs
@@ -24,6 +24,57 @@
 		}
 
 		[Test]
+		public void GetSavedSearchIds_ReturnsExpected()
+		{
+			// Arrange
+			var firstSearchId = 1234;
+			var secondSearchId = 12345;
+			var expectedSearchIds = new List<int> { firstSearchId, secondSearchId };
+			var populatedInputs = new List<JobScriptInput>
+			{
+				new JobScriptInput
+				{
+					InputId = nameof(firstSearchId),
+					InputValue = firstSearchId.ToString(),
+				},
+				new JobScriptInput
+				{
+					InputId = nameof(secondSearchId),
+					InputValue = secondSearchId.ToString(),
+				},
+				new JobScriptInput
+				{
+					InputId = "otherInput",
+					InputValue = "some other input",
+				},
+			};
+			var relativityInputs = new List<RelativityScriptInputDetails>
+			{
+				new RelativityScriptInputDetails
+				{
+					Id = nameof(firstSearchId),
+					InputType = RelativityScriptInputDetailsScriptInputType.SavedSearch,
+				},
+				new RelativityScriptInputDetails
+				{
+					Id = nameof(secondSearchId),
+					InputType = RelativityScriptInputDetailsScriptInputType.SavedSearch,
+				},
+				new RelativityScriptInputDetails
+				{
+					Id = "otherInput",
+					InputType = RelativityScriptInputDetailsScriptInputType.Constant,
+				},
+			};
+
+			// Act
+			var searchIds = this.relativityScriptProcessor.GetSavedSearchIds(populatedInputs, relativityInputs);
+
+			// Assert
+			CollectionAssert.AreEquivalent(expectedSearchIds, searchIds);
+		}
+
+		[Test]
 		public void ReplaceCaseArtifactId()
 		{
 			// Arrange
@@ -152,7 +203,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -192,7 +243,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -231,7 +282,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -276,7 +327,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -323,7 +374,7 @@ WHERE {0}.DocId = [Document].ArtifactID",
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, searchTablePrepend);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, searchTablePrepend, 1);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);

--- a/Milyli.ScriptRunner.Core.Test/UnitTests/RelativityScriptProcessorTests.cs
+++ b/Milyli.ScriptRunner.Core.Test/UnitTests/RelativityScriptProcessorTests.cs
@@ -1,0 +1,332 @@
+﻿namespace Milyli.ScriptRunner.Core.Test.UnitTests
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using global::Relativity.API;
+	using kCura.Relativity.Client;
+	using Milyli.ScriptRunner.Core.Models;
+	using Milyli.ScriptRunner.Core.Tools;
+	using Moq;
+	using NUnit.Framework;
+
+	[TestFixture(Category = "Unit")]
+	public class RelativityScriptProcessorTests
+	{
+		private RelativityScriptProcessor relativityScriptProcessor;
+		private Mock<IHelper> helperMock;
+
+		[SetUp]
+		public void Setup()
+		{
+			this.helperMock = new Mock<IHelper>(MockBehavior.Strict);
+			this.relativityScriptProcessor = new RelativityScriptProcessor(this.helperMock.Object);
+		}
+
+		[Test]
+		public void ReplaceCaseArtifactId()
+		{
+			// Arrange
+			var workspaceId = 123456;
+			var templateSql = @"UPDATE[EDDSDBO].[Foo]
+SET[Bar] = {0}";
+			var scriptSql = string.Format(templateSql, "#CaseArtifactID#");
+			var expectedSql = string.Format(templateSql, workspaceId);
+			var dbContextStub = new DBContextStub();
+			dbContextStub.IsMasterDatabase = true;
+			this.helperMock.Setup(h => h.GetDBContext(workspaceId)).Returns(dbContextStub);
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteGlobalVariables(workspaceId, scriptSql);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[Test]
+		[Description("Verifies replacement of the MasterDatabasePrepend on scripts executed in non-admin workspaces on master server")]
+		public void ReplaceEddsPrepend_WorkspaceOnMasterServer()
+		{
+			// Arrange
+			var workspaceId = 123456;
+			var templateSql = @"UPDATE {0}[Foo]
+SET[Bar] = 1";
+			var scriptSql = string.Format(templateSql, "#MasterDatabasePrepend#");
+			var expectedSql = string.Format(templateSql, "[EDDS].[EDDSDBO].");
+			var workspaceContextStub = new DBContextStub();
+			workspaceContextStub.IsMasterDatabase = false;
+			workspaceContextStub.ServerName = "coolServer";
+			var masterContextStub = new DBContextStub();
+			masterContextStub.IsMasterDatabase = true;
+			masterContextStub.ServerName = "coolServer";
+
+			this.helperMock.Setup(h => h.GetDBContext(workspaceId)).Returns(workspaceContextStub);
+			this.helperMock.Setup(h => h.GetDBContext(-1)).Returns(masterContextStub);
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteGlobalVariables(workspaceId, scriptSql);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[Test]
+		[Description("Verifies replacement of the MasterDatabasePrepend on scripts executed in non-admin workspaces on distributed servers")]
+		public void ReplaceEddsPrepend_WorkspaceOnDistributedServer()
+		{
+			// Arrange
+			var workspaceId = 123456;
+			var templateSql = @"UPDATE {0}[Foo]
+SET[Bar] = 1";
+			var scriptSql = string.Format(templateSql, "#MasterDatabasePrepend#");
+			var expectedSql = string.Format(templateSql, "[masterServer].[EDDS].[EDDSDBO].");
+			var workspaceContextStub = new DBContextStub();
+			workspaceContextStub.IsMasterDatabase = false;
+			workspaceContextStub.ServerName = "otherServer";
+			var masterContextStub = new DBContextStub();
+			masterContextStub.IsMasterDatabase = true;
+			masterContextStub.ServerName = "masterServer";
+
+			this.helperMock.Setup(h => h.GetDBContext(workspaceId)).Returns(workspaceContextStub);
+			this.helperMock.Setup(h => h.GetDBContext(-1)).Returns(masterContextStub);
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteGlobalVariables(workspaceId, scriptSql);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[Test]
+		[Description("Verifies replacement of the MasterDatabasePrepend on scripts executed in admin workspace")]
+		public void ReplaceEddsPrepend_Admin()
+		{
+			// Arrange
+			var workspaceId = -1;
+			var templateSql = @"UPDATE {0}[Foo]
+SET[Bar] = 1";
+			var scriptSql = string.Format(templateSql, "#MasterDatabasePrepend#");
+			var expectedSql = string.Format(templateSql, "[EDDS].[EDDSDBO].");
+			var masterContextStub = new DBContextStub();
+			masterContextStub.IsMasterDatabase = true;
+
+			this.helperMock.Setup(h => h.GetDBContext(workspaceId)).Returns(masterContextStub);
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteGlobalVariables(workspaceId, scriptSql);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[TestCase(RelativityScriptInputDetailsScriptInputType.Field)]
+		[TestCase(RelativityScriptInputDetailsScriptInputType.Sql)]
+		[TestCase(RelativityScriptInputDetailsScriptInputType.SearchProvider)]
+		[Description("Verifies expected replacement for script inputs which are directly substituted")]
+		public void ReplaceScriptInput_DirectReplace(RelativityScriptInputDetailsScriptInputType inputType)
+		{
+			// Arrange
+			var templateSql = @"UPDATE [Foo]
+SET[Bar] = {0}";
+
+			var inputId = "my_input";
+			var inputValue = "coolValue";
+			var expectedSql = string.Format(templateSql, inputValue);
+			var scriptSql = string.Format(templateSql, $"#{inputId}#");
+
+			var populatedInputs = new List<JobScriptInput>
+			{
+				new JobScriptInput
+				{
+					InputId = inputId,
+					InputValue = inputValue,
+				}
+			};
+			var relativityInputs = new List<RelativityScriptInputDetails>
+			{
+				new RelativityScriptInputDetails
+				{
+					Id = inputId,
+					InputType = inputType,
+				}
+			};
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[TestCase("date")]
+		[TestCase("datetime")]
+		[TestCase("text")]
+		[Description("Verifies expected replacement for constant script inputs which should be substituted as strings")]
+		public void ReplaceScriptInput_ConstantInputString(string dataType)
+		{
+			// Arrange
+			var templateSql = @"UPDATE [Foo]
+SET[Bar] = {0}";
+
+			var inputId = "my_input";
+			var inputValue = "coolValue";
+			var expectedSql = string.Format(templateSql, $"'{inputValue}'");
+			var scriptSql = string.Format(templateSql, $"#{inputId}#");
+
+			var populatedInputs = new List<JobScriptInput>
+			{
+				new JobScriptInput
+				{
+					InputId = inputId,
+					InputValue = inputValue,
+				}
+			};
+			var relativityInputs = new List<RelativityScriptInputDetails>
+			{
+				new RelativityScriptInputDetails
+				{
+					Id = inputId,
+					InputType = RelativityScriptInputDetailsScriptInputType.Constant,
+					Attributes = new Dictionary<string, string> { { "DataType", dataType } }
+				}
+			};
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[TestCase("user")]
+		[TestCase("number")]
+		[Description("Verifies expected replacement for constant script inputs which should be substituted directly")]
+		public void ReplaceScriptInput_ConstantInputDirect(string dataType)
+		{
+			// Arrange
+			var templateSql = @"UPDATE [Foo]
+SET[Bar] = {0}";
+
+			var inputId = "my_input";
+			var inputValue = "coolValue";
+			var expectedSql = string.Format(templateSql, $"{inputValue}");
+			var scriptSql = string.Format(templateSql, $"#{inputId}#");
+
+			var populatedInputs = new List<JobScriptInput>
+			{
+				new JobScriptInput
+				{
+					InputId = inputId,
+					InputValue = inputValue,
+				}
+			};
+			var relativityInputs = new List<RelativityScriptInputDetails>
+			{
+				new RelativityScriptInputDetails
+				{
+					Id = inputId,
+					InputType = RelativityScriptInputDetailsScriptInputType.Constant,
+					Attributes = new Dictionary<string, string> { { "DataType", dataType } }
+				}
+			};
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[TestCase("Central Standard Time", -6)]
+		[TestCase("Nepal Standard Time", 5.75)]
+		[Description("Verifies expected replacement for timezone inputs")]
+		public void ReplaceScriptInput_ConstantInputTimezone(string timeZoneName, decimal offset)
+		{
+			// Arrange
+			var timeZone = TimeZoneInfo.GetSystemTimeZones().FirstOrDefault(tzi => tzi.Id == timeZoneName);
+			if (timeZone.IsDaylightSavingTime(DateTime.UtcNow))
+			{
+				offset++;
+			}
+
+			var templateSql = @"UPDATE [Foo]
+SET[Bar] = {0}";
+
+			var inputId = "my_input";
+			var inputValue = timeZoneName;
+			var expectedSql = string.Format(templateSql, offset);
+			var scriptSql = string.Format(templateSql, $"#{inputId}#");
+
+			var populatedInputs = new List<JobScriptInput>
+			{
+				new JobScriptInput
+				{
+					InputId = inputId,
+					InputValue = timeZoneName,
+				}
+			};
+			var relativityInputs = new List<RelativityScriptInputDetails>
+			{
+				new RelativityScriptInputDetails
+				{
+					Id = inputId,
+					InputType = RelativityScriptInputDetailsScriptInputType.Constant,
+					Attributes = new Dictionary<string, string> { { "DataType", "timezone" } }
+				}
+			};
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+
+		[Test]
+		[Description("Verifies expected replacement for saved search inputs")]
+		public void ReplaceScriptInput_SavedSearch()
+		{
+			// Arrange
+			var templateSql = @"INSERT INTO 
+                                EDDSDBO.RelativityTempTable
+                SELECT
+                                [Document].ArtifactID,
+                                NULL
+                {0} AND [Document].ArtifactID";
+
+			var inputId = "my_input";
+			var inputValue = "123456";
+			var searchTablePrepend = Guid.NewGuid().ToString().Replace("-", string.Empty);
+			var generatedSearchTableName = searchTablePrepend + "_" + inputValue;
+			var substitutedSql = string.Format(
+				@"FROM [Document], {0} (NOLOCK)
+WHERE {0}.DocId = [Document].ArtifactID",
+				generatedSearchTableName);
+			var expectedSql = string.Format(templateSql, substitutedSql);
+			var scriptSql = string.Format(templateSql, $"#{inputId}#");
+
+			var populatedInputs = new List<JobScriptInput>
+			{
+				new JobScriptInput
+				{
+					InputId = inputId,
+					InputValue = inputValue,
+				}
+			};
+			var relativityInputs = new List<RelativityScriptInputDetails>
+			{
+				new RelativityScriptInputDetails
+				{
+					Id = inputId,
+					InputType = RelativityScriptInputDetailsScriptInputType.SavedSearch,
+				}
+			};
+
+			// Act
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, searchTablePrepend);
+
+			// Assert
+			Assert.AreEqual(expectedSql, generatedSql);
+		}
+	}
+}

--- a/Milyli.ScriptRunner.Core.Test/UnitTests/RelativityScriptProcessorTests.cs
+++ b/Milyli.ScriptRunner.Core.Test/UnitTests/RelativityScriptProcessorTests.cs
@@ -203,7 +203,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -243,7 +243,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -282,7 +282,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -327,7 +327,7 @@ SET[Bar] = {0}";
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, null, 1);
+			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);
@@ -338,6 +338,10 @@ SET[Bar] = {0}";
 		public void ReplaceScriptInput_SavedSearch()
 		{
 			// Arrange
+			var inputId = "my_input";
+			var inputValue = 123456;
+			var tableName = "CoolTable1234";
+			var tablePairs = new Dictionary<int, string> { { inputValue, tableName } };
 			var templateSql = @"INSERT INTO 
                                 EDDSDBO.RelativityTempTable
                 SELECT
@@ -345,14 +349,10 @@ SET[Bar] = {0}";
                                 NULL
                 {0} AND [Document].ArtifactID";
 
-			var inputId = "my_input";
-			var inputValue = "123456";
-			var searchTablePrepend = Guid.NewGuid().ToString().Replace("-", string.Empty);
-			var generatedSearchTableName = searchTablePrepend + "_" + inputValue;
 			var substitutedSql = string.Format(
-				@"FROM [Document], {0} (NOLOCK)
-WHERE {0}.DocId = [Document].ArtifactID",
-				generatedSearchTableName);
+				@"FROM [Document], [{0}] (NOLOCK)
+WHERE [{0}].DocId = [Document].ArtifactID",
+				tableName);
 			var expectedSql = string.Format(templateSql, substitutedSql);
 			var scriptSql = string.Format(templateSql, $"#{inputId}#");
 
@@ -361,7 +361,7 @@ WHERE {0}.DocId = [Document].ArtifactID",
 				new JobScriptInput
 				{
 					InputId = inputId,
-					InputValue = inputValue,
+					InputValue = inputValue.ToString(),
 				}
 			};
 			var relativityInputs = new List<RelativityScriptInputDetails>
@@ -374,7 +374,7 @@ WHERE {0}.DocId = [Document].ArtifactID",
 			};
 
 			// Act
-			var generatedSql = this.relativityScriptProcessor.SubstituteScriptInputs(populatedInputs, relativityInputs, scriptSql, searchTablePrepend, 1);
+			var generatedSql = this.relativityScriptProcessor.SubstituteSavedSearchTables(populatedInputs, relativityInputs, tablePairs, scriptSql);
 
 			// Assert
 			Assert.AreEqual(expectedSql, generatedSql);

--- a/Milyli.ScriptRunner.Core.Test/UnitTests/TestRelativityScriptRunner.cs
+++ b/Milyli.ScriptRunner.Core.Test/UnitTests/TestRelativityScriptRunner.cs
@@ -31,14 +31,14 @@ namespace Milyli.ScriptRunner.Core.Test.UnitTests
 			factoryMock.Setup(m => m.GetRelativityClient(It.IsAny<ExecutionIdentity>())).Returns(clientMock.Object);
 			factoryMock.Setup(m => m.GetRelativityClient()).Returns(clientMock.Object);
 
-			var result = new RelativityScriptResult()
+			var result = new ExecuteResult()
 			{
 				Success = true,
 				Message = "unit test result"
 			};
 
 			scriptExecutionRepositoryMock
-				.Setup(repo => repo.ExecuteRelativityScript(It.IsAny<RelativityScript>(), It.IsAny<List<RelativityScriptInput>>(), It.IsAny<RelativityWorkspace>())).Returns(result);
+				.Setup(repo => repo.ExecuteRelativityScript(It.IsAny<int>(), It.IsAny<List<JobScriptInput>>(), It.IsAny<RelativityWorkspace>())).Returns(result);
 
 			clientMock.Setup(m => m.APIOptions).Returns(new APIOptions(-1));
 
@@ -63,7 +63,7 @@ namespace Milyli.ScriptRunner.Core.Test.UnitTests
 			factoryMock.Setup(m => m.GetRelativityClient()).Returns(clientMock.Object);
 
 			scriptExecutionRepositoryMock
-				.Setup(repo => repo.ExecuteRelativityScript(It.IsAny<RelativityScript>(), It.IsAny<List<RelativityScriptInput>>(), It.IsAny<RelativityWorkspace>()))
+				.Setup(repo => repo.ExecuteRelativityScript(It.IsAny<int>(), It.IsAny<List<JobScriptInput>>(), It.IsAny<RelativityWorkspace>()))
 				.Throws(new Exception("None shall pass"));
 
 			clientMock.Setup(m => m.APIOptions).Returns(new APIOptions(-1));

--- a/Milyli.ScriptRunner.Core.Test/UnitTests/TestRelativityScriptRunner.cs
+++ b/Milyli.ScriptRunner.Core.Test/UnitTests/TestRelativityScriptRunner.cs
@@ -12,6 +12,7 @@ namespace Milyli.ScriptRunner.Core.Test.UnitTests
 	using kCura.Relativity.Client;
 	using kCura.Relativity.Client.DTOs;
 	using Milyli.ScriptRunner.Core.Repositories.Interfaces;
+	using Milyli.ScriptRunner.Core.Tools;
 	using Mocks;
 	using Moq;
 	using NUnit.Framework;
@@ -26,7 +27,10 @@ namespace Milyli.ScriptRunner.Core.Test.UnitTests
 		{
 			var clientMock = new Mock<IRSAPIClient>();
 			var factoryMock = new Mock<IRelativityClientFactory>();
+			var processorMock = new Mock<IRelativityScriptProcessor>();
+			var searchTableMock = new Mock<ISearchTableManager>();
 			var scriptExecutionRepositoryMock = new Mock<IRelativityScriptRepository>();
+			var helperMock = new Mock<IHelper>();
 
 			factoryMock.Setup(m => m.GetRelativityClient(It.IsAny<ExecutionIdentity>())).Returns(clientMock.Object);
 			factoryMock.Setup(m => m.GetRelativityClient()).Returns(clientMock.Object);
@@ -43,7 +47,13 @@ namespace Milyli.ScriptRunner.Core.Test.UnitTests
 			clientMock.Setup(m => m.APIOptions).Returns(new APIOptions(-1));
 
 			var jobScheduleRepositoryMock = new JobScheduleRepositoryMock();
-			var scriptRunner = new RelativityScriptRunner(jobScheduleRepositoryMock.JobScheduleRepository, factoryMock.Object, scriptExecutionRepositoryMock.Object);
+			var scriptRunner = new RelativityScriptRunner(
+				jobScheduleRepositoryMock.JobScheduleRepository,
+				factoryMock.Object,
+				scriptExecutionRepositoryMock.Object,
+				processorMock.Object,
+				searchTableMock.Object,
+				helperMock.Object);
 
 			var jobSchedule = jobScheduleRepositoryMock.CurrentJobSchedule;
 			scriptRunner.ExecuteScriptJob(jobSchedule);
@@ -59,6 +69,10 @@ namespace Milyli.ScriptRunner.Core.Test.UnitTests
 			var clientMock = new Mock<IRSAPIClient>();
 			var factoryMock = new Mock<IRelativityClientFactory>();
 			var scriptExecutionRepositoryMock = new Mock<IRelativityScriptRepository>();
+			var processorMock = new Mock<IRelativityScriptProcessor>();
+			var searchTableMock = new Mock<ISearchTableManager>();
+			var helperMock = new Mock<IHelper>();
+
 			factoryMock.Setup(m => m.GetRelativityClient(It.IsAny<ExecutionIdentity>())).Returns(clientMock.Object);
 			factoryMock.Setup(m => m.GetRelativityClient()).Returns(clientMock.Object);
 
@@ -70,7 +84,13 @@ namespace Milyli.ScriptRunner.Core.Test.UnitTests
 
 			var jobScheduleRepositoryMock = new JobScheduleRepositoryMock();
 
-			var scriptRunner = new RelativityScriptRunner(jobScheduleRepositoryMock.JobScheduleRepository, factoryMock.Object, scriptExecutionRepositoryMock.Object);
+			var scriptRunner = new RelativityScriptRunner(
+							jobScheduleRepositoryMock.JobScheduleRepository,
+							factoryMock.Object,
+							scriptExecutionRepositoryMock.Object,
+							processorMock.Object,
+							searchTableMock.Object,
+							helperMock.Object);
 			var jobSchedule = jobScheduleRepositoryMock.CurrentJobSchedule;
 
 			scriptRunner.ExecuteScriptJob(jobSchedule);

--- a/Milyli.ScriptRunner.Core.Test/app.config
+++ b/Milyli.ScriptRunner.Core.Test/app.config
@@ -1,27 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
 	<configSections>
-		<section name="kCura.Config" type="System.Configuration.DictionarySectionHandler, System, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
-    <section name="ExternalIHelperEnvironments" type="Milyli.ScriptRunner.ExternalIHelper.Config.EnvironmentsSection, Milyli.ScriptRunner.ExternalIHelper" />
+		<section name="kCura.Config" type="System.Configuration.DictionarySectionHandler, System, Version=1.0.3300.0, Culture=neutral, PublicKeyToken=b77a5c561934e089"/>
+    <section name="ExternalIHelperEnvironments" type="Milyli.ScriptRunner.ExternalIHelper.Config.EnvironmentsSection, Milyli.ScriptRunner.ExternalIHelper"/>
   </configSections>
 	<kCura.Config>
-		<add key="connectionString" value="data source=k12-r96-al;initial catalog=EDDS;persist security info=False;user id=EDDSdbo;password=Test1234!; workstation id=localhost;packet size=4096" />
+		<add key="connectionString" value="data source=k12-r96-al;initial catalog=EDDS;persist security info=False;user id=EDDSdbo;password=Test1234!; workstation id=localhost;packet size=4096"/>
 	</kCura.Config>
   <ExternalIHelperEnvironments>
-    <add ExecutingMachineName="Bill-PC" EddsServerName="k12-r95-bh" />
-    <add ExecutingMachineName="Joshua-PC" EddsServerName="k12-r95-bh" />
+    <add ExecutingMachineName="Bill-PC" EddsServerName="k12-r95-bh"/>
+    <add ExecutingMachineName="Joshua-PC" EddsServerName="k12-r95-bh"/>
     <add ExecutingMachineName="Levin-PC" EddsServerName="k12-r96-al" RsapiUserName="relativity.admin@relativity.com"/>
   </ExternalIHelperEnvironments>
 	<runtime>
 		<assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
 			<dependentAssembly>
-				<assemblyIdentity name="linq2db" publicKeyToken="f19f8aed7feff67e" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-1.0.7.6" newVersion="1.0.7.6" />
+				<assemblyIdentity name="linq2db" publicKeyToken="f19f8aed7feff67e" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-1.0.7.6" newVersion="1.0.7.6"/>
 			</dependentAssembly>
 			<dependentAssembly>
-				<assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral" />
-				<bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0" />
+				<assemblyIdentity name="Castle.Core" publicKeyToken="407dd0808d44fbdc" culture="neutral"/>
+				<bindingRedirect oldVersion="0.0.0.0-3.3.0.0" newVersion="3.3.0.0"/>
 			</dependentAssembly>
 		</assemblyBinding>
 	</runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/Milyli.ScriptRunner.Core.Test/packages.config
+++ b/Milyli.ScriptRunner.Core.Test/packages.config
@@ -5,8 +5,8 @@
   <package id="Milyli.CodeAnalysis" version="2.0.1" targetFramework="net452" />
   <package id="Moq" version="4.5.3" targetFramework="net452" />
   <package id="NLog" version="4.4.6" targetFramework="net452" />
-  <package id="NUnit" version="3.6.1" targetFramework="net452" />
-  <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net452" />
+  <package id="NUnit" version="3.11.0" targetFramework="net462" />
+  <package id="NUnit3TestAdapter" version="3.13.0" targetFramework="net462" />
   <package id="Relativity.Api" version="9.6.284.6" targetFramework="net452" />
   <package id="Relativity.EventHandler" version="9.6.284.6" targetFramework="net452" />
   <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net452" />

--- a/Milyli.ScriptRunner.Core.Test/packages.config
+++ b/Milyli.ScriptRunner.Core.Test/packages.config
@@ -7,10 +7,10 @@
   <package id="NLog" version="4.4.6" targetFramework="net452" />
   <package id="NUnit" version="3.6.1" targetFramework="net452" />
   <package id="NUnit3TestAdapter" version="3.7.0" targetFramework="net452" />
-  <package id="Relativity.Api" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.EventHandler" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.ObjectManager" version="9.5.162.111" targetFramework="net452" />
-  <package id="Relativity.Rsapi" version="9.5.69.85" targetFramework="net452" />
+  <package id="Relativity.Api" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.EventHandler" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Rsapi" version="9.6.284.6" targetFramework="net452" />
   <package id="StructureMap" version="4.4.5" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Milyli.ScriptRunner.Core/DependencyResolution/ScriptRunnerRegistry.cs
+++ b/Milyli.ScriptRunner.Core/DependencyResolution/ScriptRunnerRegistry.cs
@@ -1,12 +1,13 @@
 ﻿namespace Milyli.ScriptRunner.Core.DependencyResolution
 {
-    using DataContexts;
-    using Repositories;
-    using Services;
-    using StructureMap;
-    using Repositories.Interfaces;
+	using DataContexts;
+	using Milyli.ScriptRunner.Core.Tools;
+	using Repositories;
+	using Repositories.Interfaces;
+	using Services;
+	using StructureMap;
 
-    public class ScriptRunnerRegistry : Registry
+	public class ScriptRunnerRegistry : Registry
     {
         public ScriptRunnerRegistry()
         {
@@ -16,6 +17,7 @@
             {
                 s.AssemblyContainingType<IJobScheduleRepository>();
                 s.IncludeNamespaceContainingType<IJobScheduleRepository>();
+                s.IncludeNamespaceContainingType<IRelativityScriptProcessor>();
                 s.IncludeNamespaceContainingType<IPermissionsService>();
                 s.IncludeNamespaceContainingType<IPermissionRepository>();
                 s.IncludeNamespace("Milyli.ScriptRunner.Core.Repositories");

--- a/Milyli.ScriptRunner.Core/Milyli.ScriptRunner.Core.csproj
+++ b/Milyli.ScriptRunner.Core/Milyli.ScriptRunner.Core.csproj
@@ -167,10 +167,12 @@
     <Compile Include="Services\RelativityScriptRunner.cs" />
     <Compile Include="Tools\BitmaskHelper.cs" />
     <Compile Include="Tools\IRelativityScriptProcessor.cs" />
+    <Compile Include="Tools\ISearchTableManager.cs" />
     <Compile Include="Tools\KcuraAssemblyResolver.cs" />
     <Compile Include="Tools\RelativityHelper.cs" />
     <Compile Include="Tools\RelativityScriptProcessor.cs" />
     <Compile Include="Tools\ScheduleConversionHelper.cs" />
+    <Compile Include="Tools\SearchTableManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />

--- a/Milyli.ScriptRunner.Core/Milyli.ScriptRunner.Core.csproj
+++ b/Milyli.ScriptRunner.Core/Milyli.ScriptRunner.Core.csproj
@@ -169,6 +169,7 @@
     <Compile Include="Tools\IRelativityScriptProcessor.cs" />
     <Compile Include="Tools\KcuraAssemblyResolver.cs" />
     <Compile Include="Tools\RelativityHelper.cs" />
+    <Compile Include="Tools\RelativityScriptProcessor.cs" />
     <Compile Include="Tools\ScheduleConversionHelper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Milyli.ScriptRunner.Core/Milyli.ScriptRunner.Core.csproj
+++ b/Milyli.ScriptRunner.Core/Milyli.ScriptRunner.Core.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Milyli.ScriptRunner.Core</RootNamespace>
     <AssemblyName>Milyli.ScriptRunner.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -54,17 +55,14 @@
     <Reference Include="CronExpressionDescriptor, Version=1.21.2.0, Culture=neutral, PublicKeyToken=a2ab0e0f73f9b037, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\CronExpressionDescriptor.1.21.2\lib\net45\CronExpressionDescriptor.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Config, Version=9.5.89.76, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Other.9.5.89.76\lib\kCura.Config.dll</HintPath>
+    <Reference Include="kCura, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Other.9.6.284.6\lib\kCura.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Data.RowDataGateway, Version=9.5.89.76, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Other.9.5.89.76\lib\kCura.Data.RowDataGateway.dll</HintPath>
+    <Reference Include="kCura.EventHandler, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.6.284.6\lib\kCura.EventHandler.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.EventHandler, Version=9.5.69.85, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.5.69.85\lib\kCura.EventHandler.dll</HintPath>
-    </Reference>
-    <Reference Include="kCura.Relativity.Client, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.5.69.85\lib\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.6.284.6\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
     <Reference Include="linq2db, Version=1.0.7.6, Culture=neutral, PublicKeyToken=f19f8aed7feff67e, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\linq2db.1.7.6\lib\net45\linq2db.dll</HintPath>
@@ -75,20 +73,20 @@
     <Reference Include="Quartz, Version=2.5.0.0, Culture=neutral, PublicKeyToken=f6b8c98a402cc8a4, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\Quartz.2.5.0\lib\net40\Quartz.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Api.9.5.69.85\lib\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Api.9.6.284.6\lib\Relativity.API.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Kepler, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Kepler.dll</HintPath>
+    <Reference Include="Relativity.Kepler, Version=1.0.1.445, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Kepler.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.DataContracts, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.DataContracts.dll</HintPath>
+    <Reference Include="Relativity.Services.DataContracts, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.DataContracts.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.Interfaces, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.Interfaces.dll</HintPath>
+    <Reference Include="Relativity.Services.Interfaces, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.ServiceProxy.dll</HintPath>
+    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.392, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.0.0.315, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\structuremap.4.0.0.315\lib\net40\StructureMap.dll</HintPath>
@@ -113,6 +111,7 @@
     <Compile Include="DependencyResolution\ServiceManagerFactory.cs" />
     <Compile Include="GlobalSuppressions.cs" />
     <Compile Include="Logging\LoggingBootstrapper.cs" />
+    <Compile Include="Models\ExecuteResult.cs" />
     <Compile Include="Models\JobHistory.cs" />
     <Compile Include="Models\JobSchedule.cs" />
     <Compile Include="Models\JobScheduleWorkspace.cs" />
@@ -167,6 +166,7 @@
     <Compile Include="Services\PermissionsService.cs" />
     <Compile Include="Services\RelativityScriptRunner.cs" />
     <Compile Include="Tools\BitmaskHelper.cs" />
+    <Compile Include="Tools\IRelativityScriptProcessor.cs" />
     <Compile Include="Tools\KcuraAssemblyResolver.cs" />
     <Compile Include="Tools\RelativityHelper.cs" />
     <Compile Include="Tools\ScheduleConversionHelper.cs" />

--- a/Milyli.ScriptRunner.Core/Models/ExecuteResult.cs
+++ b/Milyli.ScriptRunner.Core/Models/ExecuteResult.cs
@@ -1,0 +1,21 @@
+﻿namespace Milyli.ScriptRunner.Core.Models
+{
+	/// <summary>
+	/// Represents the results of a Relativity Script execution.
+	/// </summary>
+	public class ExecuteResult
+	{
+		/// <summary>
+		/// Gets or sets a value indicating whether the execution was successful.
+		/// </summary>
+		public bool Success { get; set; }
+
+		/// <summary>
+		/// Gets or sets a message containing information about the execution.
+		/// </summary>
+		/// <remarks>If executed by RSAPI this may be e.g. a) a stack trace of a SQL
+		/// exception, b) validation error, etc. If executed through direct SQL this is
+		/// only set if there was an exception thrown during execution.</remarks>
+		public string Message { get; set; }
+	}
+}

--- a/Milyli.ScriptRunner.Core/Models/JobSchedule.cs
+++ b/Milyli.ScriptRunner.Core/Models/JobSchedule.cs
@@ -48,6 +48,13 @@ namespace Milyli.ScriptRunner.Core.Models
         [Column(Name = "JobEnabled")]
         public bool JobEnabled { get; set; } = true;
 
+				/// <summary>
+				/// Gets or sets a value indicating whether a job should be ran through
+				/// direct SQL rather than RSAPI.
+				/// </summary>
+				[Column(Name = "DirectSql")]
+				public bool DirectSql { get; set; } = false;
+
         /// <summary>
         /// Gets or sets the maximum runtime (in seconds) for the job
         /// </summary>

--- a/Milyli.ScriptRunner.Core/Models/JobSchedule.cs
+++ b/Milyli.ScriptRunner.Core/Models/JobSchedule.cs
@@ -1,11 +1,9 @@
-﻿
-using Milyli.ScriptRunner.Core.Repositories.Interfaces;
-
-namespace Milyli.ScriptRunner.Core.Models
+﻿namespace Milyli.ScriptRunner.Core.Models
 {
-    using System;
-    using LinqToDB.Mapping;
-    using Tools;
+	using System;
+	using LinqToDB.Mapping;
+	using Milyli.ScriptRunner.Core.Repositories.Interfaces;
+	using Tools;
 
     public enum JobStatus
     {
@@ -17,7 +15,7 @@ namespace Milyli.ScriptRunner.Core.Models
     [Table(Name = "JobSchedule")]
     public class JobSchedule : IModel<int>
     {
-        public const int NoRuntimeLimit = -1;
+        public const int DefaultTimeout = 3600;
 
         [PrimaryKey]
         [Identity]
@@ -53,13 +51,13 @@ namespace Milyli.ScriptRunner.Core.Models
 				/// direct SQL rather than RSAPI.
 				/// </summary>
 				[Column(Name = "DirectSql")]
-				public bool DirectSql { get; set; } = false;
+				public bool DirectSql { get; set; }
 
-        /// <summary>
+		    /// <summary>
         /// Gets or sets the maximum runtime (in seconds) for the job
         /// </summary>
         [Column(Name = "MaximumRuntime")]
-        public int MaximumRuntime { get; set; } = NoRuntimeLimit;
+        public int MaximumRuntime { get; set; } = DefaultTimeout;
 
         /// <summary>
         /// Gets or sets the bitmask that represents the schedule.  Only the first 7 bits (0x01 through 0x7F) are used, the LSB represents Sunday, the 7th bit represents Saturday

--- a/Milyli.ScriptRunner.Core/Relativity/RelativityDependencyRegistry.cs
+++ b/Milyli.ScriptRunner.Core/Relativity/RelativityDependencyRegistry.cs
@@ -1,20 +1,24 @@
 ﻿namespace Milyli.ScriptRunner.Core.Relativity
 {
-    using Configuration;
-    using Email;
-    using Factories;
-    using Interfaces;
-    using Repositories;
-    using Repositories.Interfaces;
-    using MilyliDependencies.Framework.Relativity;
-    using global::Relativity.API;
-    using StructureMap;
-    public class RelativityDependencyRegistry : Registry
+	using Configuration;
+	using Email;
+	using Factories;
+	using global::Relativity.API;
+	using global::Relativity.Services.Objects;
+	using Interfaces;
+	using Milyli.ScriptRunner.Core.Tools;
+	using MilyliDependencies.Framework.Relativity;
+	using Repositories;
+	using Repositories.Interfaces;
+	using StructureMap;
+
+	public class RelativityDependencyRegistry : Registry
     {
         public RelativityDependencyRegistry(IHelper helper, int workspaceId)
         {
             this.For<IHelper>().Use(helper);
             this.For<IServicesMgr>().Use(helper.GetServicesManager());
+            this.For<IObjectManager>().Use(ctx => ctx.GetInstance<IServicesMgr>().CreateProxy<IObjectManager>(ExecutionIdentity.System)).ContainerScoped();
             this.For<IRelativityContext>().Use(new RelativityContext(workspaceId));
 
             this.For<IInstanceConnectionFactory>().Use<RelativityInstanceConnectionFactory>();
@@ -24,6 +28,8 @@
             this.For<IConfigurationCryptoService>().Use<ConfigurationCryptoService>();
             this.For<IConfigurationRepository<EmailConfiguration>>().Use<ConfigurationRepository<EmailConfiguration>>();
             this.For<IEmailService>().Use<EmailService>();
-        }
+            this.For<IRelativityScriptProcessor>().Use<RelativityScriptProcessor>();
+            this.For<ISearchTableManager>().Use<SearchTableManager>();
+		}
     }
 }

--- a/Milyli.ScriptRunner.Core/Repositories/Interfaces/IRelativityScriptRepository.cs
+++ b/Milyli.ScriptRunner.Core/Repositories/Interfaces/IRelativityScriptRepository.cs
@@ -40,19 +40,5 @@
 				int scriptArtifactId,
 				List<JobScriptInput> inputs,
 				RelativityWorkspace workspace);
-
-		/// <summary>
-		/// Executes an individual script with a given list of inputs through a direct SQL connection.
-		/// </summary>
-		/// <param name="scriptArtifactId">ArtifactId of the Relativity Script to run.</param>
-		/// <param name="inputs">The <see cref="List{JobScriptInput}"/> inputs to the script</param>
-		/// <param name="workspace">the relativity workspace</param>
-		/// <param name="timeOutSeconds">Number of seconds to allow before the script execution times out.</param>
-		/// <returns><see cref="ExecuteResult"/> indicating whether the script executed successfully.</returns>
-		ExecuteResult ExecuteScriptDirectSql(
-				int scriptArtifactId,
-				List<JobScriptInput> inputs,
-				RelativityWorkspace workspace,
-				int timeOutSeconds = 600);
 	}
 }

--- a/Milyli.ScriptRunner.Core/Repositories/Interfaces/IRelativityScriptRepository.cs
+++ b/Milyli.ScriptRunner.Core/Repositories/Interfaces/IRelativityScriptRepository.cs
@@ -4,40 +4,55 @@
 	using kCura.Relativity.Client;
 	using Models;
 
-    public interface IRelativityScriptRepository
-    {
-        /// <summary>
-        /// Returns the list of scripts for a given workspace
-        /// </summary>
-        /// <param name="workspace">the application-specific workspace</param>
-        /// <returns>a list of relativity script models</returns>
-        List<RelativityScript> GetRelativityScripts(RelativityWorkspace workspace);
-
-        /// <summary>
-        /// Returns the list of given inputs for a script
-        /// </summary>
-        /// <param name="script">the application model representing a relativity script</param>
-        /// <param name="workspace">the workspace we exect to execute the script in</param>
-        /// <returns>A list of inputs</returns>
-        List<ScriptInput> GetScriptInputs(RelativityScript script, RelativityWorkspace workspace);
-
-        /// <summary>
-        /// Returns an individual script resource in a workspace for a given script id
-        /// </summary>
-        /// <param name="workspace">the relativity workspace</param>
-        /// <param name="scriptArtifactId">the artifact id for the script in the given workspace</param>
-        /// <returns>a relativity script</returns>
-        RelativityScript GetRelativityScript(RelativityWorkspace workspace, int scriptArtifactId);
+	public interface IRelativityScriptRepository
+	{
+		/// <summary>
+		/// Returns the list of scripts for a given workspace
+		/// </summary>
+		/// <param name="workspace">the application-specific workspace</param>
+		/// <returns>a list of relativity script models</returns>
+		List<RelativityScript> GetRelativityScripts(RelativityWorkspace workspace);
 
 		/// <summary>
-		/// Executes an individual script with a given list of inputs
+		/// Returns the list of given inputs for a script
 		/// </summary>
-		/// <param name="script">The <see cref="RelativityScript"/> to run</param>
-		/// <param name="inputs">The <see cref="List{RelativityScriptInput}"/> inputs to the script</param>
+		/// <param name="script">the application model representing a relativity script</param>
+		/// <param name="workspace">the workspace we exect to execute the script in</param>
+		/// <returns>A list of inputs</returns>
+		List<ScriptInput> GetScriptInputs(RelativityScript script, RelativityWorkspace workspace);
+
+		/// <summary>
+		/// Returns an individual script resource in a workspace for a given script id
+		/// </summary>
 		/// <param name="workspace">the relativity workspace</param>
-		/// <returns>a <see cref="RelativityScriptResult"/></returns>
-		RelativityScriptResult ExecuteRelativityScript(
-	    	kCura.Relativity.Client.DTOs.RelativityScript script,
-		    List<RelativityScriptInput> inputs, RelativityWorkspace workspace);
-    }
+		/// <param name="scriptArtifactId">the artifact id for the script in the given workspace</param>
+		/// <returns>a relativity script</returns>
+		RelativityScript GetRelativityScript(RelativityWorkspace workspace, int scriptArtifactId);
+
+		/// <summary>
+		/// Executes an individual script with a given list of inputs using RSAPI.
+		/// </summary>
+		/// <param name="scriptArtifactId">ArtifactId of the <see cref="RelativityScript"/> to run</param>
+		/// <param name="inputs">The <see cref="List{JobScriptInput}"/> inputs to the script</param>
+		/// <param name="workspace">the relativity workspace</param>
+		/// <returns>a <see cref="ExecuteResult"/></returns>
+		ExecuteResult ExecuteRelativityScript(
+				int scriptArtifactId,
+				List<JobScriptInput> inputs,
+				RelativityWorkspace workspace);
+
+		/// <summary>
+		/// Executes an individual script with a given list of inputs through a direct SQL connection.
+		/// </summary>
+		/// <param name="scriptArtifactId">ArtifactId of the Relativity Script to run.</param>
+		/// <param name="inputs">The <see cref="List{JobScriptInput}"/> inputs to the script</param>
+		/// <param name="workspace">the relativity workspace</param>
+		/// <param name="timeOutSeconds">Number of seconds to allow before the script execution times out.</param>
+		/// <returns><see cref="ExecuteResult"/> indicating whether the script executed successfully.</returns>
+		ExecuteResult ExecuteScriptDirectSql(
+				int scriptArtifactId,
+				List<JobScriptInput> inputs,
+				RelativityWorkspace workspace,
+				int timeOutSeconds = 600);
+	}
 }

--- a/Milyli.ScriptRunner.Core/Repositories/RelativityScriptRepository.cs
+++ b/Milyli.ScriptRunner.Core/Repositories/RelativityScriptRepository.cs
@@ -62,15 +62,6 @@
 				}, workspace);
 		}
 
-		/// <inheritdoc />
-		public ExecuteResult ExecuteScriptDirectSql(int scriptArtifactId, List<JobScriptInput> inputs, RelativityWorkspace workspace, int timeOutSeconds = 600)
-		{
-			var relativityInputs = inputs.Select(i => new RelativityScriptInput(i.InputName, i.InputValue)).ToList();
-			var script = this.InWorkspace((client, ws) => client.Repositories.RelativityScript.ReadSingle(scriptArtifactId), workspace);
-			var scriptSql = script.Body.AsXmlDocument.GetElementsByTagName("action").Item(0);
-			throw new NotImplementedException();
-		}
-
 		private T InWorkspace<T>(Func<IRSAPIClient, RelativityWorkspace, T> action, RelativityWorkspace workspace)
         {
             return RelativityHelper.InWorkspace(action, workspace, this.RelativityClient);

--- a/Milyli.ScriptRunner.Core/Services/IRelativityScriptRunner.cs
+++ b/Milyli.ScriptRunner.Core/Services/IRelativityScriptRunner.cs
@@ -1,12 +1,27 @@
 ﻿namespace Milyli.ScriptRunner.Core.Services
 {
-    using System;
-    using Milyli.ScriptRunner.Core.Models;
+	using System;
+	using Milyli.ScriptRunner.Core.Models;
 
-    public interface IRelativityScriptRunner
-    {
-        void ExecuteScriptJob(JobSchedule job);
+	public interface IRelativityScriptRunner
+	{
+		/// <summary>
+		/// Executes a <see cref="JobSchedule"/> run through direct SQL instead of executing
+		/// scripts through RSAPI.
+		/// </summary>
+		/// <param name="job"><see cref="JobSchedule"/> to run.</param>
+		void ExecuteDirectSqlJob(JobSchedule job);
 
-        void ExecuteAllJobs(DateTime executionTime);
-    }
+		/// <summary>
+		/// Executes a <see cref="JobSchedule"/> by running the Relativity Script through RSAPI.
+		/// </summary>
+		/// <param name="job"><see cref="JobSchedule"/> to run.</param>
+		void ExecuteScriptJob(JobSchedule job);
+
+		/// <summary>
+		/// Executes all jobs up scheduled to the specified time.
+		/// </summary>
+		/// <param name="executionTime">Time which specifies which scheduled jobs will be executed.</param>
+		void ExecuteAllJobs(DateTime executionTime);
+	}
 }

--- a/Milyli.ScriptRunner.Core/Services/RelativityScriptRunner.cs
+++ b/Milyli.ScriptRunner.Core/Services/RelativityScriptRunner.cs
@@ -75,6 +75,7 @@
 					var originalInputs = RelativityHelper.InWorkspace((client, _) => client.Repositories.RelativityScript.GetRelativityScriptInputs(script), workspace, this.relativityClient.GetRelativityClient());
 					var scriptSql = script.Body.AsXmlDocument.GetElementsByTagName("action").Item(0).InnerText;
 					scriptSql = this.relativityScriptProcessor.SubstituteGlobalVariables(workspace.WorkspaceId, scriptSql);
+					scriptSql = this.relativityScriptProcessor.SubstituteScriptInputs(inputs, originalInputs, scriptSql);
 					searchIds = this.relativityScriptProcessor.GetSavedSearchIds(inputs, originalInputs).ToList();
 
 					var searchTables = this.searchTableManager.CreateTablesAsync(workspace.WorkspaceId, searchIds, job.Id, job.MaximumRuntime).GetAwaiter().GetResult();

--- a/Milyli.ScriptRunner.Core/Services/RelativityScriptRunner.cs
+++ b/Milyli.ScriptRunner.Core/Services/RelativityScriptRunner.cs
@@ -83,19 +83,16 @@
 		{
 			var inputs = this.jobScheduleRepository.GetJobInputs(job);
 			Logger.Trace($"found ${inputs.Count} inputs for job ${job.Id}");
-			// new relativity script pass in artifact id
 
 			var maxAttempts = 3;
 			var attempts = 0;
-			RelativityScriptResult scriptResult = null;
+			ExecuteResult executeResult = null;
 			do
 			{
 				attempts++;
 				try
 				{
-					var script = new kCura.Relativity.Client.DTOs.RelativityScript(job.RelativityScriptId);
-					var scriptInputs = inputs.Select(i => new RelativityScriptInput(i.InputName, i.InputValue)).ToList();
-					scriptResult = this.relativityScriptRepository.ExecuteRelativityScript(script, scriptInputs, workspace);
+					executeResult = this.relativityScriptRepository.ExecuteRelativityScript(job.RelativityScriptId, inputs, workspace);
 				}
 				catch (Exception ex)
 				{
@@ -112,13 +109,13 @@
 				}
 			} while (attempts < maxAttempts);
 
-			if (scriptResult != null)
+			if (executeResult != null)
 			{
-				job.CurrentJobHistory.HasError = !scriptResult.Success;
-				job.CurrentJobHistory.ResultText = scriptResult.Message;
+				job.CurrentJobHistory.HasError = !executeResult.Success;
+				job.CurrentJobHistory.ResultText = executeResult.Message;
 				if (job.CurrentJobHistory.HasError)
 				{
-					Logger.Info($"Job {job.Id} failed with result {scriptResult.Message}");
+					Logger.Info($"Job {job.Id} failed with result {executeResult.Message}");
 				}
 			}
 			else

--- a/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
+++ b/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
@@ -6,8 +6,7 @@
 	using Milyli.ScriptRunner.Core.Models;
 
 	/// <summary>
-	/// Interface for processing Relativity Scripts and inputs
-	/// in a format which allows for direct SQL execution.
+	/// Interface for processing Relativity Scripts and inputs.
 	/// </summary>
 	public interface IRelativityScriptProcessor
 	{
@@ -27,11 +26,23 @@
 		/// <param name="relativityScriptInputDetails">List of script input descriptions from Relativity.</param>
 		/// <param name="inputSql">Sql to substitute global variables for.</param>
 		/// <param name="searchTablePrepend">String prepended to any tables created to store saved search results. This should be unique for a given script execution.</param>
+		/// <param name="scriptRunnerJobId">Id of the associated script runner job.</param>
 		/// <returns>Transformed SQL text with Relativity Script with script inputs substituted with appropriate values.</returns>
 		string SubstituteScriptInputs(
 			IEnumerable<JobScriptInput> populatedInputs,
 			IEnumerable<RelativityScriptInputDetails> relativityScriptInputDetails,
 			string inputSql,
-			string searchTablePrepend);
+			string searchTablePrepend,
+			int scriptRunnerJobId);
+
+		/// <summary>
+		/// Gets a list of saved search Ids used in execution of a relativity script.
+		/// </summary>
+		/// <param name="populatedInputs">List of populated inputs stored by ScriptRunner to use for the script execution.</param>
+		/// <param name="relativityScriptInputDetails">List of script input descriptions from Relativity.</param>
+		/// <returns>List of saved search Ids to be used during script execution.</returns>
+		IList<int> GetSavedSearchIds(
+			IEnumerable<JobScriptInput> populatedInputs,
+			IEnumerable<RelativityScriptInputDetails> relativityScriptInputDetails);
 	}
 }

--- a/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
+++ b/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
@@ -1,6 +1,5 @@
 ﻿namespace Milyli.ScriptRunner.Core.Tools
 {
-	using System;
 	using System.Collections.Generic;
 	using kCura.Relativity.Client;
 	using Milyli.ScriptRunner.Core.Models;
@@ -25,15 +24,25 @@
 		/// <param name="populatedInputs">List of populated inputs stored by ScriptRunner to use for the script execution.</param>
 		/// <param name="relativityScriptInputDetails">List of script input descriptions from Relativity.</param>
 		/// <param name="inputSql">Sql to substitute global variables for.</param>
-		/// <param name="searchTablePrepend">String prepended to any tables created to store saved search results. This should be unique for a given script execution.</param>
-		/// <param name="scriptRunnerJobId">Id of the associated script runner job.</param>
 		/// <returns>Transformed SQL text with Relativity Script with script inputs substituted with appropriate values.</returns>
 		string SubstituteScriptInputs(
 			IEnumerable<JobScriptInput> populatedInputs,
 			IEnumerable<RelativityScriptInputDetails> relativityScriptInputDetails,
-			string inputSql,
-			string searchTablePrepend,
-			int scriptRunnerJobId);
+			string inputSql);
+
+		/// <summary>
+		/// Substitutes run-time script inputs used in Relativity script for saved searches by referencing tables storing search results.
+		/// </summary>
+		/// <param name="populatedInputs">List of populated inputs stored by ScriptRunner to use for the script execution.</param>
+		/// <param name="relativityScriptInputDetails">List of script input descriptions from Relativity.</param>
+		/// <param name="searchTablePairs">Map of saved search Ids to names of tables containing search results.</param>
+		/// <param name="inputSql">Sql to substitute global variables for.</param>
+		/// <returns>Transformed SQL text with Relativity Script with script inputs substituted with appropriate values.</returns>
+		string SubstituteSavedSearchTables(
+			IEnumerable<JobScriptInput> populatedInputs,
+			IEnumerable<RelativityScriptInputDetails> relativityScriptInputDetails,
+			IDictionary<int, string> searchTablePairs,
+			string inputSql);
 
 		/// <summary>
 		/// Gets a list of saved search Ids used in execution of a relativity script.

--- a/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
+++ b/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
@@ -1,0 +1,7 @@
+﻿namespace Milyli.ScriptRunner.Core.Tools
+{
+	public interface IRelativityScriptProcessor
+	{
+
+	}
+}

--- a/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
+++ b/Milyli.ScriptRunner.Core/Tools/IRelativityScriptProcessor.cs
@@ -1,7 +1,37 @@
 ﻿namespace Milyli.ScriptRunner.Core.Tools
 {
+	using System;
+	using System.Collections.Generic;
+	using kCura.Relativity.Client;
+	using Milyli.ScriptRunner.Core.Models;
+
+	/// <summary>
+	/// Interface for processing Relativity Scripts and inputs
+	/// in a format which allows for direct SQL execution.
+	/// </summary>
 	public interface IRelativityScriptProcessor
 	{
+		/// <summary>
+		/// Substitutes global script variables used in Relativity script SQL.
+		/// </summary>
+		/// <param name="workspaceId">ArtifactId of the workspace the script will be executed in.</param>
+		/// <param name="inputSql">Sql to substitute global variables for.</param>
+		/// <returns>Transformed SQL text with Relativity Script global script variables substituted.</returns>
+		/// <remarks>Currently does not handle #LoggedInUserID#.</remarks>
+		string SubstituteGlobalVariables(int workspaceId, string inputSql);
 
+		/// <summary>
+		/// Substitutes run-time script inputs used in Relativity script SQL other than saved searches.
+		/// </summary>
+		/// <param name="populatedInputs">List of populated inputs stored by ScriptRunner to use for the script execution.</param>
+		/// <param name="relativityScriptInputDetails">List of script input descriptions from Relativity.</param>
+		/// <param name="inputSql">Sql to substitute global variables for.</param>
+		/// <param name="searchTablePrepend">String prepended to any tables created to store saved search results. This should be unique for a given script execution.</param>
+		/// <returns>Transformed SQL text with Relativity Script with script inputs substituted with appropriate values.</returns>
+		string SubstituteScriptInputs(
+			IEnumerable<JobScriptInput> populatedInputs,
+			IEnumerable<RelativityScriptInputDetails> relativityScriptInputDetails,
+			string inputSql,
+			string searchTablePrepend);
 	}
 }

--- a/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
@@ -11,30 +11,22 @@
 		/// <summary>
 		/// Creates tables containing artifact Ids of documents in a saved search.
 		/// </summary>
-		/// <param name="searchTablePrepend">String to prepend to all tables storing saved search values. This should be unique generated for each call.</param>
 		/// <param name="workspaceId">Id of the workspace to create the table in.</param>
-		/// <param name="savedSearchids">List of saved searches to create tables for.</param>
+		/// <param name="savedSearchIds">List of saved searches to create tables for.</param>
 		/// <param name="scriptRunnerJobId">Id of the associated script runner job.</param>
 		/// <param name="timeoutSeconds">Number of seconds to wait before a SQL timeout.</param>
-		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-		Task CreateTablesAsync(
-			string searchTablePrepend,
+		/// <returns>A dictionary containing names of populated save search tables indexed by searchId.</returns>
+		Task<IDictionary<int, string>> CreateTablesAsync(
 			int workspaceId,
-			IEnumerable<int> savedSearchids,
+			IEnumerable<int> savedSearchIds,
 			int scriptRunnerJobId,
 			int timeoutSeconds);
 
 		/// <summary>
 		/// Deletes all created tables corresponding to a saved search for the given prepend.
 		/// </summary>
-		/// <param name="searchTablePrepend">String to prepend to the table storing saved search values.</param>
 		/// <param name="workspaceId">Id of the workspace to create the table in.</param>
-		/// <param name="savedSearchids">List of saved searches to create tables for.</param>
-		/// <param name="scriptRunnerJobId">Id of the associated script runner job.</param>
-		void DeleteTables(
-			string searchTablePrepend,
-			int workspaceId,
-			IEnumerable<int> savedSearchids,
-			int scriptRunnerJobId);
+		/// <param name="tableNames">List tables to delete.</param>
+		void DeleteTables(int workspaceId, IEnumerable<string> tableNames);
 	}
 }

--- a/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
@@ -1,0 +1,31 @@
+﻿namespace Milyli.ScriptRunner.Core.Tools
+{
+	using System.Collections.Generic;
+	using System.Threading.Tasks;
+
+	/// <summary>
+	/// Handles operations around creating and deleting temporary tables storing documents in a saved search.
+	/// </summary>
+	public interface ISearchTableManager
+	{
+		/// <summary>
+		/// Creates tables containing artifact Ids of documents in a saved search.
+		/// </summary>
+		/// <param name="searchTablePrepend">String to prepend to all tables storing saved search values. This should be unique generated for each call.</param>
+		/// <param name="workspaceId">Id of the workspace to create the table in.</param>
+		/// <param name="savedSearchids">List of saved searches to create tables for.</param>
+		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
+		Task CreateTablesAsync(
+			string searchTablePrepend,
+			int workspaceId,
+			IEnumerable<int> savedSearchids);
+
+		/// <summary>
+		/// Deletes all created tables corresponding to a saved search for the given prepend.
+		/// </summary>
+		/// <param name="searchTablePrepend">String to prepend to the table storing saved search values.</param>
+		/// <param name="workspaceId">Id of the workspace to create the table in.</param>
+		/// <param name="savedSearchids">List of saved searches to create tables for.</param>
+		void DeleteTables(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids);
+	}
+}

--- a/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
@@ -15,12 +15,14 @@
 		/// <param name="workspaceId">Id of the workspace to create the table in.</param>
 		/// <param name="savedSearchids">List of saved searches to create tables for.</param>
 		/// <param name="scriptRunnerJobId">Id of the associated script runner job.</param>
+		/// <param name="timeoutSeconds">Number of seconds to wait before a SQL timeout.</param>
 		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 		Task CreateTablesAsync(
 			string searchTablePrepend,
 			int workspaceId,
 			IEnumerable<int> savedSearchids,
-			int scriptRunnerJobId);
+			int scriptRunnerJobId,
+			int timeoutSeconds);
 
 		/// <summary>
 		/// Deletes all created tables corresponding to a saved search for the given prepend.

--- a/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/ISearchTableManager.cs
@@ -14,11 +14,13 @@
 		/// <param name="searchTablePrepend">String to prepend to all tables storing saved search values. This should be unique generated for each call.</param>
 		/// <param name="workspaceId">Id of the workspace to create the table in.</param>
 		/// <param name="savedSearchids">List of saved searches to create tables for.</param>
+		/// <param name="scriptRunnerJobId">Id of the associated script runner job.</param>
 		/// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
 		Task CreateTablesAsync(
 			string searchTablePrepend,
 			int workspaceId,
-			IEnumerable<int> savedSearchids);
+			IEnumerable<int> savedSearchids,
+			int scriptRunnerJobId);
 
 		/// <summary>
 		/// Deletes all created tables corresponding to a saved search for the given prepend.
@@ -26,6 +28,11 @@
 		/// <param name="searchTablePrepend">String to prepend to the table storing saved search values.</param>
 		/// <param name="workspaceId">Id of the workspace to create the table in.</param>
 		/// <param name="savedSearchids">List of saved searches to create tables for.</param>
-		void DeleteTables(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids);
+		/// <param name="scriptRunnerJobId">Id of the associated script runner job.</param>
+		void DeleteTables(
+			string searchTablePrepend,
+			int workspaceId,
+			IEnumerable<int> savedSearchids,
+			int scriptRunnerJobId);
 	}
 }

--- a/Milyli.ScriptRunner.Core/Tools/RelativityScriptProcessor.cs
+++ b/Milyli.ScriptRunner.Core/Tools/RelativityScriptProcessor.cs
@@ -135,7 +135,10 @@ WHERE [{0}].DocId = [Document].ArtifactID",
 
 			foreach (var populatedInput in mappedInputs)
 			{
-				string replaceString = string.Empty;
+				var replaceToken = $"#{populatedInput.Id}#";
+
+				// By default do not modify the token, e.g. to later process saved searches
+				var replaceString = replaceToken;
 				switch (populatedInput.InputType)
 				{
 					// Field, Sql, Object, Search provider input types are all simply direct substitution
@@ -168,7 +171,7 @@ WHERE [{0}].DocId = [Document].ArtifactID",
 
 				inputSql = Regex.Replace(
 							inputSql,
-							Regex.Escape($"#{populatedInput.Id}#"),
+							Regex.Escape(replaceToken),
 							replaceString,
 							RegexOptions.IgnoreCase);
 			}

--- a/Milyli.ScriptRunner.Core/Tools/RelativityScriptProcessor.cs
+++ b/Milyli.ScriptRunner.Core/Tools/RelativityScriptProcessor.cs
@@ -1,0 +1,135 @@
+﻿namespace Milyli.ScriptRunner.Core.Tools
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Linq;
+	using System.Text.RegularExpressions;
+	using global::Relativity.API;
+	using kCura.Relativity.Client;
+	using Milyli.ScriptRunner.Core.Models;
+
+	/// <inheritdoc />
+	public class RelativityScriptProcessor : IRelativityScriptProcessor
+	{
+		private static List<string> textDataTypes = new List<string>
+		{
+			"date",
+			"datetime",
+			"text"
+		};
+
+		private readonly IHelper relativityHelper;
+
+		/// <summary>
+		/// Initializes a new instance of the <see cref="RelativityScriptProcessor"/> class.
+		/// </summary>
+		/// <param name="relativityHelper"><see cref="IHelper"/> dependency from Relativity.</param>
+		public RelativityScriptProcessor(IHelper relativityHelper)
+		{
+			this.relativityHelper = relativityHelper ?? throw new ArgumentNullException(nameof(relativityHelper));
+		}
+
+		/// <summary>
+		/// Gets name for a generated table containing a list of documents in a saved search.
+		/// </summary>
+		/// <param name="tablePrepend">Prepend used when creating the table.</param>
+		/// <param name="searchId">Id of the saved search.</param>
+		/// <returns>Generated table for the specified saved search.</returns>
+		public static string GetSearchTableName(string tablePrepend, int searchId) => tablePrepend + "_" + searchId.ToString();
+
+		/// <inheritdoc />
+		public string SubstituteGlobalVariables(int workspaceId, string inputSql)
+		{
+			inputSql = Regex.Replace(
+				inputSql,
+				Regex.Escape("#CaseArtifactID#"),
+				workspaceId.ToString(),
+				RegexOptions.IgnoreCase);
+			var workspaceDbContext = this.relativityHelper.GetDBContext(workspaceId);
+			var masterPrepend = "[EDDS].[EDDSDBO].";
+			if (!workspaceDbContext.IsMasterDatabase)
+			{
+				var workspaceServerName = workspaceDbContext.ServerName;
+				var masterDbContext = this.relativityHelper.GetDBContext(-1);
+
+				// Use four part identifier if server is not same server as EDDS main
+				masterPrepend = workspaceServerName == masterDbContext.ServerName ? masterPrepend : $"[{masterDbContext.ServerName}].{masterPrepend}";
+			}
+
+			return Regex.Replace(
+				inputSql,
+				Regex.Escape("#MasterDatabasePrepend#"),
+				masterPrepend,
+				RegexOptions.IgnoreCase);
+		}
+
+		/// <inheritdoc />
+		public string SubstituteScriptInputs(
+			IEnumerable<JobScriptInput> populatedInputs,
+			IEnumerable<RelativityScriptInputDetails> relativityScriptInputDetails,
+			string inputSql,
+			string searchTablePrepend)
+		{
+			var mappedInputs = populatedInputs.Join(
+				relativityScriptInputDetails,
+				p => p.InputId,
+				d => d.Id,
+				(p, d) => new
+				{
+					p.InputValue,
+					d.Attributes,
+					d.Id,
+					d.InputType
+				});
+
+			foreach (var populatedInput in mappedInputs)
+			{
+				string replaceString = string.Empty;
+				switch (populatedInput.InputType)
+				{
+					// Field, Sql, Object, Search provider input types are all simply direct substitution
+					// In the case of SQL inputs ScriptRunner has already saved the generated value.
+					case RelativityScriptInputDetailsScriptInputType.Field:
+					case RelativityScriptInputDetailsScriptInputType.Sql:
+					case RelativityScriptInputDetailsScriptInputType.SearchProvider:
+						replaceString = populatedInput.InputValue;
+						break;
+					case RelativityScriptInputDetailsScriptInputType.Constant:
+						// Constant inputs are typed as strings or directly substituted depending on the underying type
+						var containsDataType = populatedInput.Attributes.ContainsKey("DataType");
+						if (containsDataType && textDataTypes.Contains(populatedInput.Attributes["DataType"]))
+						{
+							replaceString = $"'{populatedInput.InputValue}'";
+						}
+						else if (containsDataType && populatedInput.Attributes["DataType"] == "timezone")
+						{
+							var timeZoneName = populatedInput.InputValue;
+							var hoursToUse = TimeZoneInfo.GetSystemTimeZones().FirstOrDefault(tzi => tzi.Id == timeZoneName).GetUtcOffset(DateTime.UtcNow).TotalHours;
+							replaceString = string.Format("{0:0.##}", hoursToUse);
+						}
+						else
+						{
+							replaceString = populatedInput.InputValue;
+						}
+
+						break;
+					case RelativityScriptInputDetailsScriptInputType.SavedSearch:
+						var searchTableName = GetSearchTableName(searchTablePrepend, Convert.ToInt32(populatedInput.InputValue));
+						replaceString = string.Format(
+							@"FROM [Document], {0} (NOLOCK)
+WHERE {0}.DocId = [Document].ArtifactID",
+							searchTableName);
+						break;
+				}
+
+				inputSql = Regex.Replace(
+							inputSql,
+							Regex.Escape($"#{populatedInput.Id}#"),
+							replaceString,
+							RegexOptions.IgnoreCase);
+			}
+
+			return inputSql;
+		}
+	}
+}

--- a/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
@@ -35,11 +35,13 @@
 			var tableDictionary = new Dictionary<int, string>();
 			const string createTableSql = @"IF OBJECT_ID('{0}') IS NOT NULL
 BEGIN
-TRUNCATE TABLE {0};
 DROP TABLE {0};
-CREATE TABLE {0} (DocId int);
+CREATE TABLE {0} (DocId INT NOT NULL PRIMARY KEY);
 END
-ELSE CREATE TABLE {0} (DocId int)";
+ELSE 
+BEGIN
+CREATE TABLE {0} (DocId INT NOT NULL PRIMARY KEY);
+END";
 			var dbContext = this.relativityHelper.GetDBContext(workspaceId);
 			foreach (var searchId in savedSearchIds.Distinct())
 			{
@@ -85,7 +87,6 @@ ELSE CREATE TABLE {0} (DocId int)";
 		{
 			const string deleteTableSql = @"IF OBJECT_ID('{0}') IS NOT NULL
 BEGIN
-TRUNCATE TABLE {0};
 DROP TABLE {0};
 END";
 			var dbContext = this.relativityHelper.GetDBContext(workspaceId);

--- a/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
@@ -14,7 +14,7 @@
 	public class SearchTableManager : ISearchTableManager
 	{
 		private const int ObjectManagerQueryBatch = 1000;
-.		private const int BulkCopyBatch = 100000;
+		private const int BulkCopyBatch = 100000;
 		private readonly IObjectManager objectManager;
 		private readonly IHelper relativityHelper;
 
@@ -25,7 +25,11 @@
 		}
 
 		/// <inheritdoc />
-		public async Task CreateTablesAsync(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids)
+		public async Task CreateTablesAsync(
+			string searchTablePrepend,
+			int workspaceId,
+			IEnumerable<int> savedSearchids,
+			int scriptRunnerJobId)
 		{
 			const string createTableSql = @"IF OBJECT_ID('{0}') IS NOT NULL
 BEGIN
@@ -36,7 +40,7 @@ ELSE CREATE TABLE {0} (DocId int)";
 			var dbContext = this.relativityHelper.GetDBContext(workspaceId);
 			foreach (var searchId in savedSearchids)
 			{
-				var tableName = RelativityScriptProcessor.GetSearchTableName(searchTablePrepend, searchId);
+				var tableName = RelativityScriptProcessor.GetSearchTableName(searchTablePrepend, searchId, scriptRunnerJobId);
 				var createSearchTableSql = string.Format(createTableSql, tableName);
 				dbContext.ExecuteNonQuerySQLStatement(createSearchTableSql);
 				var table = new DataTable();
@@ -65,7 +69,11 @@ ELSE CREATE TABLE {0} (DocId int)";
 		}
 
 		/// <inheritdoc />
-		public void DeleteTables(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids)
+		public void DeleteTables(
+			string searchTablePrepend,
+			int workspaceId,
+			IEnumerable<int> savedSearchids,
+			int scriptRunnerJobId)
 		{
 			const string deleteTableSql = @"IF OBJECT_ID('{0}') IS NOT NULL
 BEGIN
@@ -74,7 +82,7 @@ END";
 			var dbContext = this.relativityHelper.GetDBContext(workspaceId);
 			foreach (var searchId in savedSearchids)
 			{
-				var tableName = RelativityScriptProcessor.GetSearchTableName(searchTablePrepend, searchId);
+				var tableName = RelativityScriptProcessor.GetSearchTableName(searchTablePrepend, searchId, scriptRunnerJobId);
 				dbContext.ExecuteNonQuerySQLStatement(deleteTableSql);
 			}
 		}
@@ -88,6 +96,7 @@ END";
 				bulkCopy.DestinationTableName = destinationTable;
 				bulkCopy.WriteToServer(dataTable);
 			}
+
 			dataTable.Rows.Clear();
 		}
 	}

--- a/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
@@ -1,0 +1,19 @@
+﻿namespace Milyli.ScriptRunner.Core.Tools
+{
+	using System;
+	using System.Collections.Generic;
+	using System.Threading.Tasks;
+
+	public class SearchTableManager : ISearchTableManager
+	{
+		public Task CreateTablesAsync(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids)
+		{
+			throw new NotImplementedException();
+		}
+
+		public void DeleteTables(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids)
+		{
+			throw new NotImplementedException();
+		}
+	}
+}

--- a/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
@@ -2,18 +2,93 @@
 {
 	using System;
 	using System.Collections.Generic;
+	using System.Data;
+	using System.Data.SqlClient;
 	using System.Threading.Tasks;
+	using global::Relativity.API;
+	using global::Relativity.Services.Objects;
+	using global::Relativity.Services.Objects.DataContracts;
+	using kCura.Relativity.Client;
 
+	/// <inheritdoc />
 	public class SearchTableManager : ISearchTableManager
 	{
-		public Task CreateTablesAsync(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids)
+		private const int ObjectManagerQueryBatch = 1000;
+.		private const int BulkCopyBatch = 100000;
+		private readonly IObjectManager objectManager;
+		private readonly IHelper relativityHelper;
+
+		public SearchTableManager(IObjectManager objectManager, IHelper helper)
 		{
-			throw new NotImplementedException();
+			this.objectManager = objectManager ?? throw new ArgumentNullException(nameof(objectManager));
+			this.relativityHelper = helper ?? throw new ArgumentNullException(nameof(helper));
 		}
 
+		/// <inheritdoc />
+		public async Task CreateTablesAsync(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids)
+		{
+			const string createTableSql = @"IF OBJECT_ID('{0}') IS NOT NULL
+BEGIN
+DROP TABLE {0}
+CREATE TABLE {0} (DocId int)
+END
+ELSE CREATE TABLE {0} (DocId int)";
+			var dbContext = this.relativityHelper.GetDBContext(workspaceId);
+			foreach (var searchId in savedSearchids)
+			{
+				var tableName = RelativityScriptProcessor.GetSearchTableName(searchTablePrepend, searchId);
+				var createSearchTableSql = string.Format(createTableSql, tableName);
+				dbContext.ExecuteNonQuerySQLStatement(createSearchTableSql);
+				var table = new DataTable();
+				table.Columns.Add("DocId", typeof(int));
+
+				var request = new QueryRequest
+				{
+					Condition = $"'ArtifactId' IN SAVEDSEARCH {searchId}",
+					ObjectType = new ObjectTypeRef { ArtifactTypeID = (int)ArtifactType.Document },
+					Fields = new List<FieldRef>(),
+				};
+				var position = 0;
+				var results = await this.objectManager.QuerySlimAsync(workspaceId, request, position, ObjectManagerQueryBatch);
+				while (results.ResultCount > 0)
+				{
+					results.Objects.ForEach(o => table.Rows.Add(o.ArtifactID));
+					if (table.Rows.Count > BulkCopyBatch)
+					{
+						BulkInsertResults(table, dbContext, tableName);
+					}
+
+					position = results.CurrentStartIndex + ObjectManagerQueryBatch;
+					results = await this.objectManager.QuerySlimAsync(workspaceId, request, position, ObjectManagerQueryBatch);
+				}
+			}
+		}
+
+		/// <inheritdoc />
 		public void DeleteTables(string searchTablePrepend, int workspaceId, IEnumerable<int> savedSearchids)
 		{
-			throw new NotImplementedException();
+			const string deleteTableSql = @"IF OBJECT_ID('{0}') IS NOT NULL
+BEGIN
+DROP TABLE {0}
+END";
+			var dbContext = this.relativityHelper.GetDBContext(workspaceId);
+			foreach (var searchId in savedSearchids)
+			{
+				var tableName = RelativityScriptProcessor.GetSearchTableName(searchTablePrepend, searchId);
+				dbContext.ExecuteNonQuerySQLStatement(deleteTableSql);
+			}
+		}
+
+		private static void BulkInsertResults(DataTable dataTable, IDBContext dbContext, string destinationTable)
+		{
+			using (var connection = dbContext.GetConnection())
+			{
+				var bulkCopy = new SqlBulkCopy(connection);
+				bulkCopy.BulkCopyTimeout = 0;
+				bulkCopy.DestinationTableName = destinationTable;
+				bulkCopy.WriteToServer(dataTable);
+			}
+			dataTable.Rows.Clear();
 		}
 	}
 }

--- a/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
@@ -66,6 +66,11 @@ ELSE CREATE TABLE {0} (DocId int)";
 					position = results.CurrentStartIndex + ObjectManagerQueryBatch;
 					results = await this.objectManager.QuerySlimAsync(workspaceId, request, position, ObjectManagerQueryBatch);
 				}
+
+				if (table.Rows.Count > 0)
+				{
+					BulkInsertResults(table, dbContext, tableName, timeoutSeconds);
+				}
 			}
 		}
 
@@ -84,7 +89,7 @@ END";
 			foreach (var searchId in savedSearchids)
 			{
 				var tableName = RelativityScriptProcessor.GetSearchTableName(searchTablePrepend, searchId, scriptRunnerJobId);
-				dbContext.ExecuteNonQuerySQLStatement(deleteTableSql);
+				dbContext.ExecuteNonQuerySQLStatement(string.Format(deleteTableSql, tableName));
 			}
 		}
 

--- a/Milyli.ScriptRunner.Core/app.config
+++ b/Milyli.ScriptRunner.Core/app.config
@@ -1,11 +1,11 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="linq2db" publicKeyToken="f19f8aed7feff67e" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.7.5" newVersion="1.0.7.5" />
+        <assemblyIdentity name="linq2db" publicKeyToken="f19f8aed7feff67e" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.0.7.5" newVersion="1.0.7.5"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>

--- a/Milyli.ScriptRunner.Core/packages.config
+++ b/Milyli.ScriptRunner.Core/packages.config
@@ -8,11 +8,11 @@
   <package id="Milyli.CodeAnalysis" version="2.0.1" targetFramework="net452" />
   <package id="NLog" version="4.4.7" targetFramework="net452" />
   <package id="Quartz" version="2.5.0" targetFramework="net452" />
-  <package id="Relativity.Api" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.EventHandler" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.ObjectManager" version="9.5.162.111" targetFramework="net452" />
-  <package id="Relativity.Other" version="9.5.89.76" targetFramework="net452" />
-  <package id="Relativity.Rsapi" version="9.5.69.85" targetFramework="net452" />
+  <package id="Relativity.Api" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.EventHandler" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Other" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Rsapi" version="9.6.284.6" targetFramework="net452" />
   <package id="structuremap" version="4.0.0.315" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Milyli.ScriptRunner.EventHandlers/Milyli.ScriptRunner.EventHandlers.csproj
+++ b/Milyli.ScriptRunner.EventHandlers/Milyli.ScriptRunner.EventHandlers.csproj
@@ -111,6 +111,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="FodyWeavers.xml" />
+    <Content Include="SQL\AddDirectSqlJobSchedule.sql" />
     <Content Include="SQL\JobHistory.Table.sql" />
     <Content Include="SQL\JobSchedule.Table.sql" />
     <Content Include="SQL\JobScriptInput.Table.sql" />

--- a/Milyli.ScriptRunner.EventHandlers/Milyli.ScriptRunner.EventHandlers.csproj
+++ b/Milyli.ScriptRunner.EventHandlers/Milyli.ScriptRunner.EventHandlers.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Milyli.ScriptRunner.EventHandlers</RootNamespace>
     <AssemblyName>Milyli.ScriptRunner.EventHandlers</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -43,32 +44,29 @@
     <Reference Include="Dapper, Version=1.40.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\Dapper.1.42\lib\net45\Dapper.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Config, Version=9.5.89.76, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Other.9.5.89.76\lib\kCura.Config.dll</HintPath>
+    <Reference Include="kCura, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Other.9.6.284.6\lib\kCura.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Data.RowDataGateway, Version=9.5.89.76, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Other.9.5.89.76\lib\kCura.Data.RowDataGateway.dll</HintPath>
+    <Reference Include="kCura.EventHandler, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.6.284.6\lib\kCura.EventHandler.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.EventHandler, Version=9.5.69.85, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\Solutions\packages\Relativity.EventHandler.9.5.69.85\lib\kCura.EventHandler.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.6.284.6\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Relativity.Client, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.5.69.85\lib\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Api.9.6.284.6\lib\Relativity.API.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Api.9.5.69.85\lib\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.Kepler, Version=1.0.1.445, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Kepler.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Kepler, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Kepler.dll</HintPath>
+    <Reference Include="Relativity.Services.DataContracts, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.DataContracts.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.DataContracts, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.DataContracts.dll</HintPath>
+    <Reference Include="Relativity.Services.Interfaces, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.Interfaces, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.Interfaces.dll</HintPath>
-    </Reference>
-    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.ServiceProxy.dll</HintPath>
+    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.392, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="RelativityTabManager, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\RelativityTabManager.1.1.0\lib\RelativityTabManager.dll</HintPath>

--- a/Milyli.ScriptRunner.EventHandlers/RelativityApplicationConstants.Designer.cs
+++ b/Milyli.ScriptRunner.EventHandlers/RelativityApplicationConstants.Designer.cs
@@ -19,7 +19,7 @@ namespace Milyli.ScriptRunner.EventHandlers {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class RelativityApplicationConstants {

--- a/Milyli.ScriptRunner.EventHandlers/SQL/AddDirectSqlJobSchedule.sql
+++ b/Milyli.ScriptRunner.EventHandlers/SQL/AddDirectSqlJobSchedule.sql
@@ -1,0 +1,10 @@
+﻿IF NOT EXISTS (
+  SELECT * 
+  FROM   sys.columns 
+  WHERE  object_id = OBJECT_ID(N'[eddsdbo].[JobSchedule]') 
+         AND name = 'DirectSql'
+)
+BEGIN
+    ALTER TABLE [eddsdbo].[JobSchedule]
+    ADD [DirectSql] bit
+END

--- a/Milyli.ScriptRunner.EventHandlers/Services/PostInstallSqlService.cs
+++ b/Milyli.ScriptRunner.EventHandlers/Services/PostInstallSqlService.cs
@@ -24,6 +24,7 @@
             this.dbContext.ExecuteNonQuerySQLStatement(SqlScript.JobSchedule_Table);
             this.dbContext.ExecuteNonQuerySQLStatement(SqlScript.JobScriptInput_Table);
             this.dbContext.ExecuteNonQuerySQLStatement(SqlScript.JobHistory_Table);
+            this.dbContext.ExecuteNonQuerySQLStatement(SqlScript.AddDirectSqlJobSchedule);
         }
 
         public void Dispose()

--- a/Milyli.ScriptRunner.EventHandlers/SqlScript.Designer.cs
+++ b/Milyli.ScriptRunner.EventHandlers/SqlScript.Designer.cs
@@ -61,6 +61,24 @@ namespace Milyli.ScriptRunner.EventHandlers {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to IF NOT EXISTS (
+        ///  SELECT * 
+        ///  FROM   sys.columns 
+        ///  WHERE  object_id = OBJECT_ID(N&apos;[eddsdbo].[JobSchedule]&apos;) 
+        ///         AND name = &apos;DirectSql&apos;
+        ///)
+        ///BEGIN
+        ///    ALTER TABLE [eddsdbo].[JobSchedule]
+        ///    ADD [DirectSql] bit
+        ///END.
+        /// </summary>
+        internal static string AddDirectSqlJobSchedule {
+            get {
+                return ResourceManager.GetString("AddDirectSqlJobSchedule", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to IF OBJECT_ID(&apos;JobHistory&apos;, &apos;u&apos;) IS NULL
         ///BEGIN
         ///	CREATE TABLE JobHistory

--- a/Milyli.ScriptRunner.EventHandlers/SqlScript.Designer.cs
+++ b/Milyli.ScriptRunner.EventHandlers/SqlScript.Designer.cs
@@ -19,7 +19,7 @@ namespace Milyli.ScriptRunner.EventHandlers {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class SqlScript {
@@ -75,7 +75,7 @@ namespace Milyli.ScriptRunner.EventHandlers {
         ///		CONSTRAINT FK_JobHistory_JobSchedule FOREIGN KEY (JobScheduleId) REFERENCES JobSchedule(JobScheduleId)
         ///	)
         ///
-        ///	CREATE INDEX IX_JobHistory_ByScheduleStart ON JobHistory (Jo [rest of string was truncated]&quot;;.
+        ///	CREATE INDEX IX_JobHistory_ByScheduleStart ON JobHistory (JobScheduleId, S [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string JobHistory_Table {
             get {
@@ -98,7 +98,8 @@ namespace Milyli.ScriptRunner.EventHandlers {
         ///		MaximumRuntime int NOT NULL,
         ///		ExecutionTime INT NOT NULL,
         ///		ExecutionSchedule INT NOT NULL,
-        ///		CONSTRAINT PK_JobSchedule_JobScheduleId PRIMARY KEY CLUSTERED (Job [rest of string was truncated]&quot;;.
+        ///		CONSTRAINT PK_JobSchedule_JobScheduleId PRIMARY KEY CLUSTERED (JobScheduleId)
+        ///	) [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string JobSchedule_Table {
             get {
@@ -113,13 +114,14 @@ namespace Milyli.ScriptRunner.EventHandlers {
         ///	(
         ///		JobScriptInputId int not null IDENTITY(1,1),
         ///		JobScheduleId int not null,
+        ///		InputId nvarchar(255) not null,
         ///		InputName nvarchar(255) not null,
         ///		InputValue nvarchar(max),
         ///		CONSTRAINT PK_JobScriptInput_JobScriptInputId PRIMARY KEY CLUSTERED (JobScriptInputId),
         ///		CONSTRAINT FK_JobScriptInput_JobSchedule FOREIGN KEY (JobScheduleId) REFERENCES JobSchedule(JobScheduleId)
         ///	)
         ///
-        ///	CREATE INDEX IX_JobScriptInput_JobScheduleId ON JobScriptInput(JobSchedul [rest of string was truncated]&quot;;.
+        ///	CREATE INDEX IX_JobScriptInput_JobScheduleId ON Job [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string JobScriptInput_Table {
             get {
@@ -142,7 +144,8 @@ namespace Milyli.ScriptRunner.EventHandlers {
         ///		MaximumRuntime int NOT NULL,
         ///		ExecutionTime INT NOT NULL,
         ///		ExecutionSchedule INT NOT NULL,
-        ///		CONSTRAINT PK_JobSchedule_JobScheduleId PRIMARY KEY CLUSTERED (Job [rest of string was truncated]&quot;;.
+        ///		CONSTRAINT PK_JobSchedule_JobScheduleId PRIMARY KEY CLUSTERED (JobScheduleId)
+        ///	) [rest of string was truncated]&quot;;.
         /// </summary>
         internal static string ScriptRunnerSchema {
             get {

--- a/Milyli.ScriptRunner.EventHandlers/SqlScript.resx
+++ b/Milyli.ScriptRunner.EventHandlers/SqlScript.resx
@@ -118,6 +118,9 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <assembly alias="System.Windows.Forms" name="System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" />
+  <data name="AddDirectSqlJobSchedule" type="System.Resources.ResXFileRef, System.Windows.Forms">
+    <value>sql\adddirectsqljobschedule.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
+  </data>
   <data name="JobHistory_Table" type="System.Resources.ResXFileRef, System.Windows.Forms">
     <value>SQL\JobHistory.Table.sql;System.String, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089;utf-8</value>
   </data>

--- a/Milyli.ScriptRunner.EventHandlers/packages.config
+++ b/Milyli.ScriptRunner.EventHandlers/packages.config
@@ -2,12 +2,12 @@
 <packages>
   <package id="Costura.Fody" version="1.4.1" targetFramework="net452" developmentDependency="true" />
   <package id="Dapper" version="1.42" targetFramework="net452" />
-  <package id="Fody" version="2.0.6" targetFramework="net452" developmentDependency="true" />
-  <package id="Relativity.Api" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.EventHandler" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.ObjectManager" version="9.5.162.111" targetFramework="net452" />
-  <package id="Relativity.Other" version="9.5.89.76" targetFramework="net452" />
-  <package id="Relativity.Rsapi" version="9.5.69.85" targetFramework="net452" />
+  <package id="Fody" version="2.0.6" targetFramework="net452" developmentDependency="true" requireReinstallation="true" />
+  <package id="Relativity.Api" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.EventHandler" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Other" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Rsapi" version="9.6.284.6" targetFramework="net452" />
   <package id="RelativityTabManager" version="1.1.0" targetFramework="net452" />
   <package id="StyleCop.Analyzers" version="1.0.0" targetFramework="net452" developmentDependency="true" />
 </packages>

--- a/Milyli.ScriptRunner.ExternalIHelper/ExternalIHelper.cs
+++ b/Milyli.ScriptRunner.ExternalIHelper/ExternalIHelper.cs
@@ -166,19 +166,6 @@
 			throw new NotImplementedException();
 		}
 
-#if V9_6_26_97 || V9_6_85_9
-		public ISecretStore GetSecretStore()
-		{
-			throw new NotImplementedException();
-		}
-#endif
-
-#if V9_6_85_9
-		public IInstanceSettingsBundle GetInstanceSettingBundle()
-		{
-			throw new NotImplementedException();
-		}
-#endif
 		public class Settings
 		{
 			public string EddsServerName { get; set; }

--- a/Milyli.ScriptRunner.ExternalIHelper/ExternalIHelper.cs
+++ b/Milyli.ScriptRunner.ExternalIHelper/ExternalIHelper.cs
@@ -156,6 +156,16 @@
 			throw new NotImplementedException();
 		}
 
+		public ISecretStore GetSecretStore()
+		{
+			throw new NotImplementedException();
+		}
+
+		public IInstanceSettingsBundle GetInstanceSettingBundle()
+		{
+			throw new NotImplementedException();
+		}
+
 #if V9_6_26_97 || V9_6_85_9
 		public ISecretStore GetSecretStore()
 		{

--- a/Milyli.ScriptRunner.ExternalIHelper/Milyli.ScriptRunner.ExternalIHelper.csproj
+++ b/Milyli.ScriptRunner.ExternalIHelper/Milyli.ScriptRunner.ExternalIHelper.csproj
@@ -37,9 +37,9 @@
     <DefineConstants Condition="'$(RelativityAPIVersion)' != ''">$(DefineConstants);V$(RelativityAPIVersion.Replace(".", "_"))</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Relativity.Api" Version="$(RelativityVersion)" /> 
-    <PackageReference Include="Relativity.ObjectManager" Version="9.5.162.111" />
-    <PackageReference Include="Relativity.Other" Version="$(RelativityVersion)" />
+    <PackageReference Include="Relativity.Api" Version="9.6.284.6" /> 
+    <PackageReference Include="Relativity.ObjectManager" Version="9.6.284.6" />
+    <PackageReference Include="Relativity.Other" Version="9.6.284.6" />
     <PackageReference Include="Milyli.CodeAnalysis" Version="2.0.1">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
@@ -64,5 +64,6 @@
   <!-- Workaround for https://github.com/dotnet/roslyn-project-system/issues/1739 -->
   <PropertyGroup>
     <AssemblySearchPaths>$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
+    <TargetFramework>net462</TargetFramework>
   </PropertyGroup>
 </Project>

--- a/Milyli.ScriptRunner.Services.Interfaces/Milyli.ScriptRunner.Services.Interfaces.csproj
+++ b/Milyli.ScriptRunner.Services.Interfaces/Milyli.ScriptRunner.Services.Interfaces.csproj
@@ -31,8 +31,17 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Relativity.Kepler, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Kepler.dll</HintPath>
+    <Reference Include="Relativity.Kepler, Version=1.0.1.445, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Kepler.dll</HintPath>
+    </Reference>
+    <Reference Include="Relativity.Services.DataContracts, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.DataContracts.dll</HintPath>
+    </Reference>
+    <Reference Include="Relativity.Services.Interfaces, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.Interfaces.dll</HintPath>
+    </Reference>
+    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.392, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -49,13 +58,13 @@
     <Compile Include="V1\IServiceModule.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\Milyli.ScriptRunner.Services.Contracts\Milyli.ScriptRunner.Services.Contracts.csproj">
       <Project>{ce861b8e-4e96-4de9-a778-77c5c17d77a0}</Project>
       <Name>Milyli.ScriptRunner.Services.Contracts</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Milyli.ScriptRunner.Services.Interfaces/packages.config
+++ b/Milyli.ScriptRunner.Services.Interfaces/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Relativity.ObjectManager" version="9.5.162.111" targetFramework="net461" />
+  <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net462" />
 </packages>

--- a/Milyli.ScriptRunner.Web/Milyli.ScriptRunner.Web.csproj
+++ b/Milyli.ScriptRunner.Web/Milyli.ScriptRunner.Web.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Milyli.ScriptRunner.Web</RootNamespace>
     <AssemblyName>Milyli.ScriptRunner.Web</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
     <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort />
@@ -53,8 +53,8 @@
     <Reference Include="Antlr3.Runtime, Version=3.5.0.2, Culture=neutral, PublicKeyToken=eb42632606e9261f, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\Antlr.3.5.0.2\lib\Antlr3.Runtime.dll</HintPath>
     </Reference>
-    <Reference Include="kCura.Relativity.Client, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.5.69.85\lib\kCura.Relativity.Client.dll</HintPath>
+    <Reference Include="kCura.Relativity.Client, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Rsapi.9.6.284.6\lib\kCura.Relativity.Client.dll</HintPath>
     </Reference>
     <Reference Include="linq2db, Version=1.0.7.6, Culture=neutral, PublicKeyToken=f19f8aed7feff67e, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\linq2db.1.7.6\lib\net45\linq2db.dll</HintPath>
@@ -69,23 +69,23 @@
     <Reference Include="Newtonsoft.Json, Version=10.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.API, Version=9.5.69.85, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.Api.9.5.69.85\lib\Relativity.API.dll</HintPath>
+    <Reference Include="Relativity.API, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.Api.9.6.284.6\lib\Relativity.API.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.CustomPages, Version=9.5.69.85, Culture=neutral, processorArchitecture=AMD64">
-      <HintPath>..\Solutions\packages\Relativity.CustomPages.9.5.69.85\lib\Relativity.CustomPages.dll</HintPath>
+    <Reference Include="Relativity.CustomPages, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.CustomPages.9.6.284.6\lib\Relativity.CustomPages.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Kepler, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Kepler.dll</HintPath>
+    <Reference Include="Relativity.Kepler, Version=1.0.1.445, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Kepler.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.DataContracts, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.DataContracts.dll</HintPath>
+    <Reference Include="Relativity.Services.DataContracts, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.DataContracts.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.Interfaces, Version=9.5.162.111, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.Interfaces.dll</HintPath>
+    <Reference Include="Relativity.Services.Interfaces, Version=9.6.284.6, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.Interfaces.dll</HintPath>
     </Reference>
-    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.312, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.5.162.111\lib\Relativity.Services.ServiceProxy.dll</HintPath>
+    <Reference Include="Relativity.Services.ServiceProxy, Version=1.0.1.392, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\Solutions\packages\Relativity.ObjectManager.9.6.284.6\lib\Relativity.Services.ServiceProxy.dll</HintPath>
     </Reference>
     <Reference Include="StructureMap, Version=4.5.1.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\StructureMap.4.5.1\lib\net45\StructureMap.dll</HintPath>
@@ -105,9 +105,12 @@
       <HintPath>..\Solutions\packages\Microsoft.Net.Http.2.2.29\lib\net45\System.Net.Http.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Web.ApplicationServices" />
+    <Reference Include="System.Web.DynamicData" />
     <Reference Include="System.Web.Entity" />
     <Reference Include="System.ComponentModel.DataAnnotations" />
     <Reference Include="System.Web" />
+    <Reference Include="System.Web.Extensions" />
     <Reference Include="System.Web.Helpers, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\Solutions\packages\Microsoft.AspNet.WebPages.3.2.3\lib\net45\System.Web.Helpers.dll</HintPath>
     </Reference>

--- a/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
+++ b/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
@@ -101,7 +101,7 @@
                     });
 
 										JobScheduleModel.TimeoutInvalid = ko.computed(function () {
-											return JobScheduleModel.JobSchedule.DirectSql ? JobScheduleModel.JobSchedule.MaximumRuntime < 30 : false;
+											return JobScheduleModel.JobSchedule.DirectSql() ? JobScheduleModel.JobSchedule.MaximumRuntime() < 30 : false;
 										});
 
 										JobScheduleModel.InputsInvalid = ko.computed(function () {

--- a/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
+++ b/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
@@ -98,7 +98,7 @@
                             return jobScriptInput.InputName();
                         });
                         return invalidInputs;
-                    })
+                    });
 
 										JobScheduleModel.TimeoutInvalid = ko.computed(function () {
 											return JobScheduleModel.JobSchedule.DirectSql ? JobScheduleModel.JobSchedule.MaximumRuntime < 30 : false;
@@ -109,7 +109,7 @@
 										});
 
                     JobScheduleModel.IsInvalid = ko.computed(function () {
-											return JobScheduleModel.InputsInvalid || JobScheduleModel.TimeoutInvalid;
+											return JobScheduleModel.InputsInvalid() || JobScheduleModel.TimeoutInvalid();
                     });
 
                     JobScheduleModel.InvalidText = ko.computed(function () {

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -74,7 +74,7 @@
         <div class="schedule-section">
             <h4>Script Inputs</h4>
             <div data-bind="foreach: JobScriptInputs" class="script-inputs">
-                <div class="input-container" data-bind="css: { required : IsRequired(), invalid : InputsInvalid() }">
+                <div class="input-container" data-bind="css: { required : IsRequired(), invalid : IsInvalid() }">
                     <label data-bind="text: InputName">
                     </label>
                     <div data-bind="ifnot : HasOptions">

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -31,7 +31,7 @@
                         <input data-bind="checked : DirectSql" type="checkbox" class="form-check-input" id="directSql">
                     </div>
                     <div data-bind="visible: DirectSql">
-                        <label>Maximum Timeout (seconds)</label>
+                        <label>Maximum SQL Timeout (seconds)</label>
                         <input data-bind="value : MaximumRuntime" type="number" min="30" max="86400" step="1" value="3600"/>
                     </div>
                 </div>

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -88,7 +88,7 @@
         </div>
         <div class="schedule-footer">
             <div data-bind="css : { 'error-notification' : IsInvalid() }, text : InvalidText"></div>
-            <button class="btn btn-primary" id="save-job-schedule" data-bind="click: SaveJobSchedule, disable: (!HasName() || IsInvalid), attr {title : InvalidText}">Save</button>
+            <button class="btn btn-primary" id="save-job-schedule" data-bind="click: SaveJobSchedule, disable: (!HasName() || IsInvalid()), attr {title : InvalidText}">Save</button>
         </div>
         <div class="run-script-container">
             <iframe id="run-script" src="/Relativity/Case/RelativityScript/Run.aspx?AppID=@Model.RelativityWorkspace.WorkspaceId&ArtifactID=@Model.RelativityScript.RelativityScriptId"></iframe>

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -20,12 +20,20 @@
                     <label>Job Name</label><input id="JobName" class="form-control" type="text" data-bind="value : Name, style: { borderColor: Name().length < 1 ? 'red' : 'black'}" maxlength="255" /><br />
                     <label>Last Execution Time</label><span data-bind="text : LastExecutionTimeString"></span><br />
                     <label>Next Execution Time</label> <span data-bind="text : NextExecutionTimeString"></span><br />
-                    <label>Exectues At</label> 
-                    <input data-bind="value : ExecutionTimeHours" type="number" min="1" max="12" step="1"/>:<input data-bind="value : ExecutionTimeMinutes" type="number" min="0" max="59" step="1"/>
+                    <label>Exectues At</label>
+                    <input data-bind="value : ExecutionTimeHours" type="number" min="1" max="12" step="1" />:<input data-bind="value : ExecutionTimeMinutes" type="number" min="0" max="59" step="1" />
                     <select data-bind="value:ExecutionTimeMeridian">
                         <option>AM</option>
                         <option>PM</option>
                     </select>
+                    <div class="form-check">
+                        <label class="form-check-label" for="directSql">Execute Through Direct SQL</label>
+                        <input data-bind="checked : DirectSql" type="checkbox" class="form-check-input" id="directSql">
+                    </div>
+                    <div data-bind="visible: DirectSql">
+                        <label>Maximum Timeout (seconds)</label>
+                        <input data-bind="value : MaximumRuntime" type="number" min="30" max="86400" step="1" value="3600"/>
+                    </div>
                 </div>
                 <div data-bind="with: RelativityWorkspace">
                     <label>Workspace</label><a href="@Url.Action("List", "RelativityScript", new { relativityWorkspaceId = Model.RelativityWorkspace.WorkspaceId })">@Model.RelativityWorkspace.Name</a>
@@ -66,7 +74,7 @@
         <div class="schedule-section">
             <h4>Script Inputs</h4>
             <div data-bind="foreach: JobScriptInputs" class="script-inputs">
-                <div class="input-container" data-bind="css: { required : IsRequired(), invalid : IsInvalid() }">
+                <div class="input-container" data-bind="css: { required : IsRequired(), invalid : InputsInvalid() }">
                     <label data-bind="text: InputName">
                     </label>
                     <div data-bind="ifnot : HasOptions">

--- a/Milyli.ScriptRunner.Web/packages.config
+++ b/Milyli.ScriptRunner.Web/packages.config
@@ -26,10 +26,10 @@
   <package id="Moment.js" version="2.6.0" targetFramework="net452" />
   <package id="Moment.Timezone.js" version="0.5.13" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="10.0.3" targetFramework="net452" />
-  <package id="Relativity.Api" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.CustomPages" version="9.5.69.85" targetFramework="net452" />
-  <package id="Relativity.ObjectManager" version="9.5.162.111" targetFramework="net452" />
-  <package id="Relativity.Rsapi" version="9.5.69.85" targetFramework="net452" />
+  <package id="Relativity.Api" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.CustomPages" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net452" />
+  <package id="Relativity.Rsapi" version="9.6.284.6" targetFramework="net452" />
   <package id="StructureMap" version="4.5.1" targetFramework="net452" />
   <package id="StructureMap.MVC5" version="3.1.1.134" targetFramework="net452" />
   <package id="structuremap.web" version="4.0.0.315" targetFramework="net452" />


### PR DESCRIPTION
To get around timeout issues seen when using RSAPI to execute Relativity scripts (which does not seem to seem to register the timeout specified on the script) this adds the ability to execute a script through direct SQL.

To do so  the appropriate variables (global variables and user inputs) have to be substituted in the relativity script SQL, and in addition to this saved searches must be handled separately as the service which compiles SQL from Saved Searches is not exposed in a public API. Variable substitution is fairly straightforward, but supporting saved searches required saving the results of the search to an external table and referencing that table in the substituted script SQL. Temp tables were avoided as saved searches may potentially contain tens of millions of results, and using a physical table (cleaned up at the end of the job) avoids the necessity of a potentially extremely long-lasting SQL connection.

**NOTE**: This PR bumps up the minimum Relativity version to 9.6.284 as it uses ObjectManager to access results of saved searches.