### PR TITLE
Fix ExternalIHelper project+build to run from command line

### DIFF
--- a/Milyli.ScriptRunner.Core.Test/Milyli.ScriptRunner.Core.Test.csproj
+++ b/Milyli.ScriptRunner.Core.Test/Milyli.ScriptRunner.Core.Test.csproj
@@ -117,7 +117,7 @@
       <Name>Milyli.ScriptRunner.Core</Name>
     </ProjectReference>
     <ProjectReference Include="..\Milyli.ScriptRunner.ExternalIHelper\Milyli.ScriptRunner.ExternalIHelper.csproj">
-      <Project>{93E3793A-0139-4081-BD91-C3C7B10AE989}</Project>
+      <Project>{93e3793a-0139-4081-bd91-c3c7b10ae989}</Project>
       <Name>Milyli.ScriptRunner.ExternalIHelper</Name>
     </ProjectReference>
   </ItemGroup>

--- a/Milyli.ScriptRunner.ExternalIHelper/Milyli.ScriptRunner.ExternalIHelper.csproj
+++ b/Milyli.ScriptRunner.ExternalIHelper/Milyli.ScriptRunner.ExternalIHelper.csproj
@@ -1,11 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <RelativityAPIVersion Condition="'$(RelativityAPIVersion)' == ''">9.5.89.76</RelativityAPIVersion>
-  </PropertyGroup>
+
 
   <PropertyGroup>
     <PackageId>Milyli.ScriptRunner.ExternalIHelper</PackageId>
-    <Version>$(RelativityAPIVersion)</Version>
+    <Version>9.6.284.6</Version>
     <Authors />
     <Company>Milyli, Inc.</Company>
     <Product>Milyli.ScriptRunner.ExternalIHelper</Product>
@@ -14,28 +12,10 @@
     <AssemblyName>Milyli.ScriptRunner.ExternalIHelper</AssemblyName>
     <RootNamespace>Milyli.ScriptRunner.ExternalIHelper</RootNamespace>
     <CodeAnalysisRuleSet>ProjectSettings.ruleset</CodeAnalysisRuleSet>
+    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   
-  <PropertyGroup Condition="'$(RelativityAPIVersion)' == '9.5.89.76'">
-    <TargetFramework>net451</TargetFramework>
-    <RelativityVersion>[9.5.89.76,9.5.169.7)</RelativityVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(RelativityAPIVersion)' == '9.5.169.7'">
-    <TargetFramework>net462</TargetFramework>
-    <RelativityVersion>[9.5.169.7,9.6.26.97)</RelativityVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(RelativityAPIVersion)' == '9.6.26.97'">
-    <TargetFramework>net462</TargetFramework>
-    <RelativityVersion>[9.6.26.97,9.6.85.9)</RelativityVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(RelativityAPIVersion)' == '9.6.85.9'">
-    <TargetFramework>net462</TargetFramework>
-    <RelativityVersion>9.6.85.9</RelativityVersion>
-  </PropertyGroup>
-
-  <PropertyGroup>
-    <DefineConstants Condition="'$(RelativityAPIVersion)' != ''">$(DefineConstants);V$(RelativityAPIVersion.Replace(".", "_"))</DefineConstants>
-  </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Relativity.Api" Version="9.6.284.6" /> 
     <PackageReference Include="Relativity.ObjectManager" Version="9.6.284.6" />
@@ -65,5 +45,11 @@
   <PropertyGroup>
     <AssemblySearchPaths>$(AssemblySearchPaths);{GAC}</AssemblySearchPaths>
     <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <OutputPath>bin\Debug\</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <OutputPath>bin\Release\</OutputPath>
   </PropertyGroup>
 </Project>

--- a/Milyli.ScriptRunner.ExternalIHelper/packages.config
+++ b/Milyli.ScriptRunner.ExternalIHelper/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Relativity.Api" version="9.6.284.6" targetFramework="net462" />
+  <package id="Relativity.ObjectManager" version="9.6.284.6" targetFramework="net462" />
+  <package id="Relativity.Other" version="9.6.284.6" targetFramework="net462" />
+</packages>


### PR DESCRIPTION
The ExternalIHelper project wasn't configured right to build using the command line unit test option when the dual-Relativity version support was removed. This fixes the project so the build/unit test command line script will work again.