### PR TITLE
b(savedsearch): Batch starting with a 1 index

### DIFF
--- a/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
+++ b/Milyli.ScriptRunner.Core/Tools/SearchTableManager.cs
@@ -57,7 +57,7 @@ END";
 					ObjectType = new ObjectTypeRef { ArtifactTypeID = (int)ArtifactType.Document },
 					Fields = new List<FieldRef>(),
 				};
-				var position = 0;
+				var position = 1;
 				var results = await this.objectManager.QuerySlimAsync(workspaceId, request, position, ObjectManagerQueryBatch);
 				while (results.ResultCount > 0)
 				{


### PR DESCRIPTION
### TLDR;

Object Manager starts at index 1 for some inexplicable reason. We were grabbing the 1000th document twice and it was blowing up the saved search replacement.