### PR TITLE
Create button strip out of Job Actions

### DIFF
--- a/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
+++ b/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
@@ -148,7 +148,7 @@
         };
         var viewmodel = ko.viewmodel.fromModel(model, options);
         
-        viewmodel.SaveJobSchedule = function () {
+        function internalSaveJobSchedule(postSaveAction) {
           mask();
           $.ajax({
                 type: 'POST',
@@ -164,12 +164,19 @@
                             }
                             else {
                                 ko.viewmodel.updateFromModel(viewmodel, data);
+                                if (!!postSaveAction) {
+                                    postSaveAction(viewmodel);
+                                }
                             }
                         })
                         .fail(error)
                         .always(function (data) {
                             unmask();
                         });
+        };
+
+        viewmodel.SaveJobSchedule = function () {
+            internalSaveJobSchedule();
         };
 
         viewmodel.DisableJob = function () {
@@ -183,23 +190,21 @@
         };
 
 
-        viewmodel.RunJob = function (jobScheduleModel) {
-            mask();
-            $.ajax({
-                type: 'POST',
-                url: actions.Run,
-                processData: false,
-                dataType: 'json',
-                contentType: "application/json",
-                data: ko.toJSON(jobScheduleModel.JobSchedule)
-            })
-                        .done(function (data) {
-                            ko.viewmodel.updateFromModel(viewmodel, data)
-                        })
-                        .fail(error)
-                        .always(function (data) {
-                            unmask();
-                        });
+        viewmodel.RunJob = function () {
+            internalSaveJobSchedule(function (jobScheduleModel) {
+                $.ajax({
+                    type: 'POST',
+                    url: actions.Run,
+                    processData: false,
+                    dataType: 'json',
+                    contentType: "application/json",
+                    data: ko.toJSON(jobScheduleModel.JobSchedule)
+                })
+                    .done(function (data) {
+                        ko.viewmodel.updateFromModel(viewmodel, data)
+                    })
+                    .fail(error);
+            });
         };
 
         self.UpdateOptions = function (selectableInputValues) {

--- a/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
+++ b/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
@@ -73,6 +73,13 @@
                         return JobScheduleModel.JobSchedule.JobEnabled() && !JobScheduleModel.IsNew()
                     });
 
+                    JobScheduleModel.EnableDisableText = ko.computed(function () {
+                        if (JobScheduleModel.JobSchedule.JobEnabled()) {
+                            return "Disable";
+                        }
+                        return "Enabled";
+                    })
+
                     JobScheduleModel.JobStatusName = ko.computed(function () {
                         if (JobScheduleModel.IsNew()) {
                             return "New";
@@ -179,16 +186,10 @@
             internalSaveJobSchedule();
         };
 
-        viewmodel.DisableJob = function () {
-            viewmodel.JobSchedule.JobEnabled(false);
+        viewmodel.EnableDisableJob = function () {
+            viewmodel.JobSchedule.JobEnabled(!ko.unwrap(viewmodel.JobSchedule.JobEnabled));
             self.SaveJobSchedule();
         };
-
-        viewmodel.EnableJob = function () {
-            viewmodel.JobSchedule.JobEnabled(true);
-            self.SaveJobSchedule();
-        };
-
 
         viewmodel.RunJob = function () {
             internalSaveJobSchedule(function (jobScheduleModel) {

--- a/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
+++ b/Milyli.ScriptRunner.Web/Scripts/ViewModel/JobScheduleViewModel.js
@@ -77,7 +77,7 @@
                         if (JobScheduleModel.JobSchedule.JobEnabled()) {
                             return "Disable";
                         }
-                        return "Enabled";
+                        return "Enable";
                     })
 
                     JobScheduleModel.JobStatusName = ko.computed(function () {
@@ -188,7 +188,7 @@
 
         viewmodel.EnableDisableJob = function () {
             viewmodel.JobSchedule.JobEnabled(!ko.unwrap(viewmodel.JobSchedule.JobEnabled));
-            self.SaveJobSchedule();
+            internalSaveJobSchedule();
         };
 
         viewmodel.RunJob = function () {

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -79,12 +79,12 @@
             <div data-bind="css : { 'error-notification' : IsInvalid() }, text : InvalidText"></div>
             <div class="btn-group" role="group">
                 <button class="btn btn-primary" id="save-job-schedule" data-bind="click: SaveJobSchedule, disable: (!HasName() || IsInvalid()), attr {title : InvalidText}">Save</button>
-                <span data-bind="if: AllowRun">
+                <!-- ko if: AllowRun -->
                     <button class="btn btn-secondary" data-bind="click: RunJob">Save and Run</button>
-                </span>
-                <span data-bind="if: !IsNew()">
+                <!-- /ko -->
+                <!-- ko if: !IsNew() -->
                     <button class="btn btn-secondary" data-bind="text: EnableDisableText, click: EnableDisableJob">Enable/Disable</button>
-                </span>
+                <!-- /ko -->
             </div>
         </div>
         <div class="run-script-container">

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -79,9 +79,12 @@
             <div data-bind="css : { 'error-notification' : IsInvalid() }, text : InvalidText"></div>
             <div class="btn-group" role="group">
                 <button class="btn btn-primary" id="save-job-schedule" data-bind="click: SaveJobSchedule, disable: (!HasName() || IsInvalid()), attr {title : InvalidText}">Save</button>
-                <button data-bind="visible: AllowRun, click: RunJob">Save and Run</button>
-                <button data-bind="visible: !IsNew() && JobSchedule.JobEnabled(), click: DisableJob">Disable</button>
-                <button data-bind="visible: !IsNew() && !JobSchedule.JobEnabled(), click: EnableJob">Enable</button> 
+                <span data-bind="if: AllowRun">
+                    <button class="btn btn-secondary" data-bind="click: RunJob">Save and Run</button>
+                </span>
+                <span data-bind="if: !IsNew()">
+                    <button class="btn btn-secondary" data-bind="text: EnableDisableText, click: EnableDisableJob">Enable/Disable</button>
+                </span>
             </div>
         </div>
         <div class="run-script-container">

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -79,7 +79,7 @@
             <div data-bind="css : { 'error-notification' : IsInvalid() }, text : InvalidText"></div>
             <div class="btn-group" role="group">
                 <button class="btn btn-primary" id="save-job-schedule" data-bind="click: SaveJobSchedule, disable: (!HasName() || IsInvalid()), attr {title : InvalidText}">Save</button>
-                <button data-bind="visible: AllowRun, click: RunJob">Run</button>
+                <button data-bind="visible: AllowRun, click: RunJob">Save and Run</button>
                 <button data-bind="visible: !IsNew() && JobSchedule.JobEnabled(), click: DisableJob">Disable</button>
                 <button data-bind="visible: !IsNew() && !JobSchedule.JobEnabled(), click: EnableJob">Enable</button> 
             </div>

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -45,17 +45,6 @@
                 </div>
                 <div>
                     <label>Job Status</label><span data-bind="text : JobStatusName"></span>
-                    <span data-bind="if : AllowRun">
-                        <button data-bind="click: RunJob">Run</button>
-                    </span>
-                    <span data-bind="ifnot : IsNew">
-                        <span data-bind="if: JobSchedule.JobEnabled()">
-                            <button data-bind="click: DisableJob">Disable</button>
-                        </span>
-                        <span data-bind="ifnot: JobSchedule.JobEnabled()">
-                            <button data-bind="click: EnableJob">Enable</button>
-                        </span>
-                    </span>
                 </div>
             </div>
             <div class="day-picker">
@@ -88,7 +77,12 @@
         </div>
         <div class="schedule-footer">
             <div data-bind="css : { 'error-notification' : IsInvalid() }, text : InvalidText"></div>
-            <button class="btn btn-primary" id="save-job-schedule" data-bind="click: SaveJobSchedule, disable: (!HasName() || IsInvalid()), attr {title : InvalidText}">Save</button>
+            <div class="btn-group" role="group">
+                <button class="btn btn-primary" id="save-job-schedule" data-bind="click: SaveJobSchedule, disable: (!HasName() || IsInvalid()), attr {title : InvalidText}">Save</button>
+                <button data-bind="visible: AllowRun, click: RunJob">Run</button>
+                <button data-bind="visible: !IsNew() && JobSchedule.JobEnabled(), click: DisableJob">Disable</button>
+                <button data-bind="visible: !IsNew() && !JobSchedule.JobEnabled(), click: EnableJob">Enable</button> 
+            </div>
         </div>
         <div class="run-script-container">
             <iframe id="run-script" src="/Relativity/Case/RelativityScript/Run.aspx?AppID=@Model.RelativityWorkspace.WorkspaceId&ArtifactID=@Model.RelativityScript.RelativityScriptId"></iframe>


### PR DESCRIPTION
### TLDR;

The behavior around running and enabling/disabling script runner scheduled jobs was confusing and split into 2 button groups.

We've pulled the Run and Enable/Disable buttons down into the button group with the Save button. A bug was fixed with enable/disable so it will save the schedule once it's clicked and no longer requires clicking save. The Run button has become a Save and Run button.
