### PR TITLE
Fix JobHistory display issues

### DIFF
--- a/Milyli.ScriptRunner.Core/Models/JobHistory.cs
+++ b/Milyli.ScriptRunner.Core/Models/JobHistory.cs
@@ -31,7 +31,7 @@ namespace Milyli.ScriptRunner.Core.Models
 
         internal void UpdateRuntime()
         {
-            this.Runtime = DateTime.UtcNow.Subtract(this.StartTime).Seconds;
+            this.Runtime = (int)DateTime.UtcNow.Subtract(this.StartTime).TotalSeconds;
         }
     }
 }

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -99,7 +99,7 @@
     <div id="job-schedule-history">
         <h3>Job history</h3>
         <a href="javascript:void window.open('/Relativity/Audit.aspx?AppID=@Model.RelativityWorkspace.WorkspaceId&ArtifactID=@Model.RelativityScript.RelativityScriptId&ArtifactTypeID=@RelativityScript.ScriptArtifactTypeId','audithistory','height=500,width=800,location=no,scrollbars=yes,menubar=no,toolbar=no,status=no,resizable=yes');">Audit (opens in new window)</a>
-        <table>
+        <table class="table table-bordered table-striped">
             <thead>
                 <tr>
                     <th colspan="3" class="pagination">
@@ -126,11 +126,14 @@
                     <th>Result</th>
                 </tr>
             </thead>
-            <tbody data-bind="if: JobHistory().length == 0">
+            <!-- ko if: (JobHistory().length == 0)-->
+            <tbody>
                 <tr>
                     <td>No Previous Jobs</td>
                 </tr>
             </tbody>
+            <!-- /ko -->
+            <!-- ko if: (JobHistory().length > 0)-->
             <tbody data-bind="foreach: JobHistory">
                 <tr>
                     <td data-bind="text : StartTimeString"></td>
@@ -145,6 +148,7 @@
                     </td>
                 </tr>
             </tbody>
+            <!-- /ko -->
         </table>
     </div>
     }

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -139,7 +139,7 @@
                         <span data-bind="if : HasError">
                             <span data-bind="text: ResultText"></span>
                         </span>
-                        <span data-bind="ifnot : HasError">
+                        <span data-bind="if : (!HasError() && (Runtime() != null))">
                             Success
                         </span>
                     </td>


### PR DESCRIPTION
- Fixes a bug where jobs would immediately show "Success" when an agent first picked it up, even if the job wasn't complete
- Fixes a bug where the Runtime was calculated incorrectly
- Adds bootstrap classes to make the jobhistory table easier to read
  - Uses comment-style KO-if to prevent two tbody elements from being present in the DOM