### PR TITLE
Specify UTC and fix typo on schedule edit page

### DIFF
--- a/Milyli.ScriptRunner.Web/Controllers/JobScheduleController.cs
+++ b/Milyli.ScriptRunner.Web/Controllers/JobScheduleController.cs
@@ -51,8 +51,8 @@
 		{
 			var jobSchedule = jobScheduleModel.JobSchedule;
 
-			// Convert local schedule to UTC before saving
-			jobSchedule.NextExecutionTime = jobSchedule.GetNextExecution(DateTime.UtcNow);
+			// Converting local schedule to UTC is done later
+			jobSchedule.NextExecutionTime = jobSchedule.GetNextExecution(DateTime.Now);
 			// Warning! This has to be done after calculating the next execution.
 			// Doing the calculation breaks for executions expected later today if we convert first
 			jobSchedule = jobSchedule.ConvertLocalToUtc();

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -18,9 +18,9 @@
                 <h4>Job Details</h4>
                 <div data-bind="with: JobSchedule">
                     <label>Job Name</label><input id="JobName" class="form-control" type="text" data-bind="value : Name, style: { borderColor: Name().length < 1 ? 'red' : 'black'}" maxlength="255" /><br />
-                    <label>Last Execution Time</label><span data-bind="text : LastExecutionTimeString"></span><br />
-                    <label>Next Execution Time</label> <span data-bind="text : NextExecutionTimeString"></span><br />
-                    <label>Exectues At</label>
+                    <label>Last Execution Time (UTC)</label><span data-bind="text : LastExecutionTimeString"></span><br />
+                    <label>Next Execution Time (UTC)</label> <span data-bind="text : NextExecutionTimeString"></span><br />
+                    <label>Executes At (UTC)</label>
                     <input data-bind="value : ExecutionTimeHours" type="number" min="1" max="12" step="1" />:<input data-bind="value : ExecutionTimeMinutes" type="number" min="0" max="59" step="1" />
                     <select data-bind="value:ExecutionTimeMeridian">
                         <option>AM</option>

--- a/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/JobSchedule/EditSchedule.cshtml
@@ -18,9 +18,9 @@
                 <h4>Job Details</h4>
                 <div data-bind="with: JobSchedule">
                     <label>Job Name</label><input id="JobName" class="form-control" type="text" data-bind="value : Name, style: { borderColor: Name().length < 1 ? 'red' : 'black'}" maxlength="255" /><br />
-                    <label>Last Execution Time (UTC)</label><span data-bind="text : LastExecutionTimeString"></span><br />
-                    <label>Next Execution Time (UTC)</label> <span data-bind="text : NextExecutionTimeString"></span><br />
-                    <label>Executes At (UTC)</label>
+                    <label>Last Execution Time</label><span data-bind="text : LastExecutionTimeString"></span><br />
+                    <label>Next Execution Time</label> <span data-bind="text : NextExecutionTimeString"></span><br />
+                    <label>Executes At</label>
                     <input data-bind="value : ExecutionTimeHours" type="number" min="1" max="12" step="1" />:<input data-bind="value : ExecutionTimeMinutes" type="number" min="0" max="59" step="1" />
                     <select data-bind="value:ExecutionTimeMeridian">
                         <option>AM</option>

--- a/Milyli.ScriptRunner.Web/Views/RelativityScript/List.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/RelativityScript/List.cshtml
@@ -28,10 +28,10 @@
                         Schedule Count
                     </th>
 					<th>
-						Last Execution Time
+						Last Execution Time (UTC)
 					</th>
                     <th>
-                        Next Execution Time
+                        Next Execution Time (UTC)
                     </th>
                     <th>
                     </th>

--- a/Milyli.ScriptRunner.Web/Views/RelativityScript/List.cshtml
+++ b/Milyli.ScriptRunner.Web/Views/RelativityScript/List.cshtml
@@ -28,10 +28,10 @@
                         Schedule Count
                     </th>
 					<th>
-						Last Execution Time (UTC)
+						Last Execution Time
 					</th>
                     <th>
-                        Next Execution Time (UTC)
+                        Next Execution Time
                     </th>
                     <th>
                     </th>


### PR DESCRIPTION
- Ensure whenever "Last/Next Execution Time" is specified in the UI, it is noted that the time is in UTC
- Fix and issue where dates were being "double-converted" to UTC, causing the next execution of a script to sometimes be skipped.